### PR TITLE
feat(cli): add `app logs` command

### DIFF
--- a/cli/cmd/app/app.go
+++ b/cli/cmd/app/app.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"numerous/cli/cmd/app/deploy"
+	"numerous/cli/cmd/app/logs"
 
 	"github.com/spf13/cobra"
 )
@@ -24,4 +25,5 @@ var AppRootCmd = &cobra.Command{
 
 func init() {
 	AppRootCmd.AddCommand(deploy.DeployCmd)
+	AppRootCmd.AddCommand(logs.LogsCmd)
 }

--- a/cli/cmd/app/logs/cmd.go
+++ b/cli/cmd/app/logs/cmd.go
@@ -2,7 +2,11 @@ package logs
 
 import (
 	"fmt"
+	"net/http"
 	"os"
+
+	"numerous/cli/internal/app"
+	"numerous/cli/internal/gql"
 
 	"github.com/spf13/cobra"
 )
@@ -55,14 +59,16 @@ var (
 )
 
 func run(cmd *cobra.Command, args []string) {
-	var printer func(AppDeployLogEntry)
+	var printer func(app.AppDeployLogEntry)
 	if timestamps {
 		printer = TimestampPrinter
 	} else {
 		printer = TextPrinter
 	}
+	sc := gql.NewSubscriptionClient().WithSyncMode(true)
+	service := app.New(gql.NewClient(), sc, http.DefaultClient)
 
-	if err := Logs(cmd.Context(), nil, appDir, slug, appName, printer); err != nil {
+	if err := Logs(cmd.Context(), service, appDir, slug, appName, printer); err != nil {
 		os.Exit(1)
 	} else {
 		os.Exit(0)

--- a/cli/cmd/app/logs/cmd.go
+++ b/cli/cmd/app/logs/cmd.go
@@ -1,0 +1,77 @@
+package logs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var LogsCmd = &cobra.Command{
+	Use:   "logs [app directory]",
+	Run:   run,
+	Short: "Deploy an app to an organization.",
+	Long: `Read the logs of an application deployed to an organization on the
+Numerous platform.
+
+If <name> and <organization> flags are set, they define the app to read logs
+from. If they are not the default deployment section in the manifest is used,
+if it is defined.
+
+If [app directory] is specified, that directory will be used to read the
+app manifest for the default deployment information.
+
+If no [app directory] is specified, the current working directory is used.`,
+	Example: `To read the logs from a specific app deployment, use the following form:
+
+    numerous app logs --organization "organization-slug-a2ecf59b" --name "my-app"
+
+Otherwise, assuming an app has been initialized in the directory
+"my_project/my_app" and has a default deployment defined in its manifest:
+
+    numerous app logs my_project/my_app
+`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			fn := cmd.HelpFunc()
+			fn(cmd, args)
+
+			return fmt.Errorf("accepts only an optional [app directory] as a positional argument, you provided %d arguments", len(args))
+		}
+
+		if len(args) == 1 {
+			appDir = args[0]
+		}
+
+		return nil
+	},
+}
+
+var (
+	slug       string
+	appName    string
+	timestamps bool
+	appDir     string = "."
+)
+
+func run(cmd *cobra.Command, args []string) {
+	var printer func(AppDeployLogEntry)
+	if timestamps {
+		printer = TimestampPrinter
+	} else {
+		printer = TextPrinter
+	}
+
+	if err := Logs(cmd.Context(), nil, appDir, slug, appName, printer); err != nil {
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
+}
+
+func init() {
+	flags := LogsCmd.Flags()
+	flags.StringVarP(&slug, "organization", "o", "", "The organization slug identifier of the app to read logs from.")
+	flags.StringVarP(&appName, "name", "n", "", "The name of the app to read logs from.")
+	flags.BoolVarP(&timestamps, "timestamps", "t", false, "Print a timestamp for each log entry.")
+}

--- a/cli/cmd/app/logs/cmd.go
+++ b/cli/cmd/app/logs/cmd.go
@@ -19,7 +19,7 @@ var LogsCmd = &cobra.Command{
 Numerous platform.
 
 If <name> and <organization> flags are set, they define the app to read logs
-from. If they are not the default deployment section in the manifest is used,
+from. If they are not, the default deployment section in the manifest is used,
 if it is defined.
 
 If [app directory] is specified, that directory will be used to read the

--- a/cli/cmd/app/logs/logs.go
+++ b/cli/cmd/app/logs/logs.go
@@ -1,0 +1,102 @@
+package logs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"numerous/cli/cmd/output"
+	"numerous/cli/cmd/validate"
+	"numerous/cli/manifest"
+)
+
+var (
+	ErrInvalidSlug    = errors.New("invalid organization slug")
+	ErrInvalidAppName = errors.New("invalid app name")
+)
+
+type AppDeployLogEntry struct {
+	Timestamp time.Time
+	Text      string
+}
+
+type AppService interface {
+	AppDeployLogs(slug, appName string) (chan AppDeployLogEntry, error)
+}
+
+func Logs(ctx context.Context, apps AppService, appDir, slug, appName string, printer func(AppDeployLogEntry)) error {
+	slug, appName, err := getAppIdentifier(appDir, slug, appName)
+	if err != nil {
+		return err
+	}
+
+	ch, err := apps.AppDeployLogs(slug, appName)
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case entry, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			printer(entry)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func getAppIdentifier(appDir string, slug string, appName string) (string, string, error) {
+	// load manifest if either slug or appName is missing
+	if slug == "" || appName == "" {
+		manifest, err := manifest.LoadManifest(filepath.Join(appDir, manifest.ManifestPath))
+		if err != nil {
+			output.PrintErrorAppNotInitialized(appDir)
+
+			return "", "", err
+		}
+
+		if slug == "" && manifest.Deployment != nil {
+			slug = manifest.Deployment.OrganizationSlug
+		}
+
+		if appName == "" && manifest.Deployment != nil {
+			appName = manifest.Deployment.AppName
+		}
+	}
+
+	if !validate.IsValidIdentifier(slug) {
+		if slug == "" {
+			output.PrintErrorMissingOrganizationSlug()
+		} else {
+			output.PrintErrorInvalidOrganizationSlug(slug)
+		}
+
+		return "", "", ErrInvalidSlug
+	}
+
+	if !validate.IsValidIdentifier(appName) {
+		if appName == "" {
+			output.PrintErrorMissingAppName()
+		} else {
+			output.PrintErrorInvalidAppName(appName)
+		}
+
+		return "", "", ErrInvalidAppName
+	}
+
+	return slug, appName, nil
+}
+
+func TimestampPrinter(entry AppDeployLogEntry) {
+	ts := output.AnsiFaint + entry.Timestamp.Format(time.RFC3339) + output.AnsiReset
+	fmt.Println(ts + " " + entry.Text)
+}
+
+func TextPrinter(entry AppDeployLogEntry) {
+	fmt.Println(entry.Text)
+}

--- a/cli/cmd/app/logs/logs.go
+++ b/cli/cmd/app/logs/logs.go
@@ -9,6 +9,7 @@ import (
 
 	"numerous/cli/cmd/output"
 	"numerous/cli/cmd/validate"
+	"numerous/cli/internal/app"
 	"numerous/cli/manifest"
 )
 
@@ -17,16 +18,11 @@ var (
 	ErrInvalidAppName = errors.New("invalid app name")
 )
 
-type AppDeployLogEntry struct {
-	Timestamp time.Time
-	Text      string
-}
-
 type AppService interface {
-	AppDeployLogs(slug, appName string) (chan AppDeployLogEntry, error)
+	AppDeployLogs(slug, appName string) (chan app.AppDeployLogEntry, error)
 }
 
-func Logs(ctx context.Context, apps AppService, appDir, slug, appName string, printer func(AppDeployLogEntry)) error {
+func Logs(ctx context.Context, apps AppService, appDir, slug, appName string, printer func(app.AppDeployLogEntry)) error {
 	slug, appName, err := getAppIdentifier(appDir, slug, appName)
 	if err != nil {
 		return err
@@ -92,11 +88,11 @@ func getAppIdentifier(appDir string, slug string, appName string) (string, strin
 	return slug, appName, nil
 }
 
-func TimestampPrinter(entry AppDeployLogEntry) {
+func TimestampPrinter(entry app.AppDeployLogEntry) {
 	ts := output.AnsiFaint + entry.Timestamp.Format(time.RFC3339) + output.AnsiReset
 	fmt.Println(ts + " " + entry.Text)
 }
 
-func TextPrinter(entry AppDeployLogEntry) {
+func TextPrinter(entry app.AppDeployLogEntry) {
 	fmt.Println(entry.Text)
 }

--- a/cli/cmd/app/logs/logs_test.go
+++ b/cli/cmd/app/logs/logs_test.go
@@ -1,0 +1,129 @@
+package logs
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"numerous/cli/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func dummyPrinter(entry AppDeployLogEntry) {}
+
+func TestLogs(t *testing.T) {
+	const slug = "organization-slug"
+	const appName = "app-name"
+	testError := errors.New("test error")
+
+	t.Run("given invalid slug then it returns error", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
+
+		err := Logs(context.TODO(), nil, appDir, "Some Invalid Organization Slug", appName, dummyPrinter)
+
+		assert.ErrorIs(t, err, ErrInvalidSlug)
+	})
+
+	t.Run("given invalid app name then it returns error", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
+
+		err := Logs(context.TODO(), nil, appDir, slug, "Some Invalid App Name", dummyPrinter)
+
+		assert.ErrorIs(t, err, ErrInvalidAppName)
+	})
+
+	t.Run("given neither slug nor app name arguments and numerous.toml without deploy then it returns error", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../../testdata/streamlit_app_without_deploy", appDir)
+
+		err := Logs(context.TODO(), nil, appDir, "", "", dummyPrinter)
+
+		assert.ErrorIs(t, err, ErrInvalidSlug)
+	})
+
+	t.Run("given no slug and app name arguments and app dir without numerous.toml then it returns error", func(t *testing.T) {
+		appDir := t.TempDir()
+
+		err := Logs(context.TODO(), nil, appDir, "", "", dummyPrinter)
+
+		assert.ErrorContains(t, err, "no such file or directory")
+	})
+
+	t.Run("given slug and app name arguments but not app dir then it calls service as expected", func(t *testing.T) {
+		closedCh := make(chan AppDeployLogEntry)
+		close(closedCh)
+		apps := &AppServiceMock{}
+		apps.On("AppDeployLogs", slug, appName).Return(closedCh, nil)
+
+		err := Logs(context.TODO(), apps, "", slug, appName, dummyPrinter)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("given numerous.toml with deploy section then it calls service as expected", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
+
+		closedCh := make(chan AppDeployLogEntry)
+		close(closedCh)
+		apps := &AppServiceMock{}
+		apps.On("AppDeployLogs", "organization-slug-in-manifest", "app-name-in-manifest").Return(closedCh, nil)
+
+		err := Logs(context.TODO(), apps, appDir, "", "", dummyPrinter)
+
+		assert.NoError(t, err)
+		apps.AssertExpectations(t)
+	})
+
+	t.Run("it stops when context is cancelled", func(t *testing.T) {
+		ch := make(chan AppDeployLogEntry)
+		apps := &AppServiceMock{}
+		apps.On("AppDeployLogs", slug, appName).Return(ch, nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(time.Millisecond * 10)
+			cancel()
+		}()
+		err := Logs(ctx, apps, "", slug, appName, dummyPrinter)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("given app service returns error, it returns the error", func(t *testing.T) {
+		var nilChan chan AppDeployLogEntry = nil
+		apps := &AppServiceMock{}
+		apps.On("AppDeployLogs", slug, appName).Return(nilChan, testError)
+
+		err := Logs(context.TODO(), apps, "", slug, appName, dummyPrinter)
+
+		assert.ErrorIs(t, err, testError)
+	})
+
+	t.Run("prints expected entries", func(t *testing.T) {
+		ch := make(chan AppDeployLogEntry)
+		apps := &AppServiceMock{}
+		apps.On("AppDeployLogs", slug, appName).Return(ch, nil)
+
+		entry1 := AppDeployLogEntry{Timestamp: time.Date(2024, time.March, 1, 1, 1, 1, 1, time.UTC)}
+		entry2 := AppDeployLogEntry{Timestamp: time.Date(2024, time.March, 1, 2, 2, 2, 2, time.UTC)}
+		expected := []AppDeployLogEntry{entry1, entry2}
+		actual := []AppDeployLogEntry{}
+		printer := func(e AppDeployLogEntry) {
+			actual = append(actual, e)
+		}
+		go func() {
+			defer close(ch)
+			ch <- entry1
+			ch <- entry2
+		}()
+		err := Logs(context.TODO(), apps, "", slug, appName, printer)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, actual)
+	})
+}

--- a/cli/cmd/app/logs/logs_test.go
+++ b/cli/cmd/app/logs/logs_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"numerous/cli/internal/app"
 	"numerous/cli/test"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func dummyPrinter(entry AppDeployLogEntry) {}
+func dummyPrinter(entry app.AppDeployLogEntry) {}
 
 func TestLogs(t *testing.T) {
 	const slug = "organization-slug"
@@ -54,7 +55,7 @@ func TestLogs(t *testing.T) {
 	})
 
 	t.Run("given slug and app name arguments but not app dir then it calls service as expected", func(t *testing.T) {
-		closedCh := make(chan AppDeployLogEntry)
+		closedCh := make(chan app.AppDeployLogEntry)
 		close(closedCh)
 		apps := &AppServiceMock{}
 		apps.On("AppDeployLogs", slug, appName).Return(closedCh, nil)
@@ -68,7 +69,7 @@ func TestLogs(t *testing.T) {
 		appDir := t.TempDir()
 		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
 
-		closedCh := make(chan AppDeployLogEntry)
+		closedCh := make(chan app.AppDeployLogEntry)
 		close(closedCh)
 		apps := &AppServiceMock{}
 		apps.On("AppDeployLogs", "organization-slug-in-manifest", "app-name-in-manifest").Return(closedCh, nil)
@@ -80,7 +81,7 @@ func TestLogs(t *testing.T) {
 	})
 
 	t.Run("it stops when context is cancelled", func(t *testing.T) {
-		ch := make(chan AppDeployLogEntry)
+		ch := make(chan app.AppDeployLogEntry)
 		apps := &AppServiceMock{}
 		apps.On("AppDeployLogs", slug, appName).Return(ch, nil)
 
@@ -95,7 +96,7 @@ func TestLogs(t *testing.T) {
 	})
 
 	t.Run("given app service returns error, it returns the error", func(t *testing.T) {
-		var nilChan chan AppDeployLogEntry = nil
+		var nilChan chan app.AppDeployLogEntry = nil
 		apps := &AppServiceMock{}
 		apps.On("AppDeployLogs", slug, appName).Return(nilChan, testError)
 
@@ -105,15 +106,15 @@ func TestLogs(t *testing.T) {
 	})
 
 	t.Run("prints expected entries", func(t *testing.T) {
-		ch := make(chan AppDeployLogEntry)
+		ch := make(chan app.AppDeployLogEntry)
 		apps := &AppServiceMock{}
 		apps.On("AppDeployLogs", slug, appName).Return(ch, nil)
 
-		entry1 := AppDeployLogEntry{Timestamp: time.Date(2024, time.March, 1, 1, 1, 1, 1, time.UTC)}
-		entry2 := AppDeployLogEntry{Timestamp: time.Date(2024, time.March, 1, 2, 2, 2, 2, time.UTC)}
-		expected := []AppDeployLogEntry{entry1, entry2}
-		actual := []AppDeployLogEntry{}
-		printer := func(e AppDeployLogEntry) {
+		entry1 := app.AppDeployLogEntry{Timestamp: time.Date(2024, time.March, 1, 1, 1, 1, 1, time.UTC)}
+		entry2 := app.AppDeployLogEntry{Timestamp: time.Date(2024, time.March, 1, 2, 2, 2, 2, time.UTC)}
+		expected := []app.AppDeployLogEntry{entry1, entry2}
+		actual := []app.AppDeployLogEntry{}
+		printer := func(e app.AppDeployLogEntry) {
 			actual = append(actual, e)
 		}
 		go func() {

--- a/cli/cmd/app/logs/logs_test.go
+++ b/cli/cmd/app/logs/logs_test.go
@@ -20,18 +20,12 @@ func TestLogs(t *testing.T) {
 	testError := errors.New("test error")
 
 	t.Run("given invalid slug then it returns error", func(t *testing.T) {
-		appDir := t.TempDir()
-		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
-
 		err := Logs(context.TODO(), nil, appDir, "Some Invalid Organization Slug", appName, dummyPrinter)
 
 		assert.ErrorIs(t, err, ErrInvalidSlug)
 	})
 
 	t.Run("given invalid app name then it returns error", func(t *testing.T) {
-		appDir := t.TempDir()
-		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
-
 		err := Logs(context.TODO(), nil, appDir, slug, "Some Invalid App Name", dummyPrinter)
 
 		assert.ErrorIs(t, err, ErrInvalidAppName)

--- a/cli/cmd/app/logs/mock.go
+++ b/cli/cmd/app/logs/mock.go
@@ -1,6 +1,10 @@
 package logs
 
-import "github.com/stretchr/testify/mock"
+import (
+	"numerous/cli/internal/app"
+
+	"github.com/stretchr/testify/mock"
+)
 
 var _ AppService = &AppServiceMock{}
 
@@ -9,7 +13,7 @@ type AppServiceMock struct {
 }
 
 // AppDeployLogs implements AppService.
-func (m *AppServiceMock) AppDeployLogs(slug string, appName string) (chan AppDeployLogEntry, error) {
+func (m *AppServiceMock) AppDeployLogs(slug string, appName string) (chan app.AppDeployLogEntry, error) {
 	args := m.Called(slug, appName)
-	return args.Get(0).(chan AppDeployLogEntry), args.Error(1)
+	return args.Get(0).(chan app.AppDeployLogEntry), args.Error(1)
 }

--- a/cli/cmd/app/logs/mock.go
+++ b/cli/cmd/app/logs/mock.go
@@ -1,0 +1,15 @@
+package logs
+
+import "github.com/stretchr/testify/mock"
+
+var _ AppService = &AppServiceMock{}
+
+type AppServiceMock struct {
+	mock.Mock
+}
+
+// AppDeployLogs implements AppService.
+func (m *AppServiceMock) AppDeployLogs(slug string, appName string) (chan AppDeployLogEntry, error) {
+	args := m.Called(slug, appName)
+	return args.Get(0).(chan AppDeployLogEntry), args.Error(1)
+}

--- a/cli/internal/app/app_deploy_logs.go
+++ b/cli/internal/app/app_deploy_logs.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"time"
+
+	"github.com/hasura/go-graphql-client/pkg/jsonutil"
+)
+
+type AppDeployLogEntry struct {
+	Timestamp time.Time
+	Text      string
+}
+
+type AppDeployLogsSubscription struct {
+	AppDeployLogs AppDeployLogEntry `graphql:"appDeployLogs(input: {organizationSlug: $slug, appName: $name})"`
+}
+
+func (s *Service) AppDeployLogs(slug, name string) (chan AppDeployLogEntry, error) {
+	ch := make(chan AppDeployLogEntry)
+
+	handler := func(message []byte, err error) error {
+		if err != nil {
+			return err
+		}
+
+		var value AppDeployLogsSubscription
+
+		err = jsonutil.UnmarshalGraphQL(message, &value)
+		if err != nil {
+			return err
+		}
+
+		ch <- value.AppDeployLogs
+
+		return nil
+	}
+
+	vars := make(map[string]any)
+	vars["slug"] = slug
+	vars["name"] = name
+	_, err := s.subscription.Subscribe(&AppDeployLogsSubscription{}, vars, handler)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer close(ch)
+		s.subscription.Run() // nolint:errcheck
+	}()
+
+	return ch, nil
+}

--- a/cli/internal/app/app_deploy_logs_test.go
+++ b/cli/internal/app/app_deploy_logs_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"numerous/cli/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppDeployLogs(t *testing.T) {
+	clientCh := make(chan test.SubMessage, 10)
+	c := test.CreateTestSubscriptionClient(t, clientCh)
+	s := New(nil, c, nil)
+
+	ch, err := s.AppDeployLogs("organization-slug", "app-name")
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	actual := []AppDeployLogEntry{}
+	go func() {
+		defer wg.Done()
+
+		for {
+			select {
+			case <-time.After(time.Second):
+				return
+			case e, ok := <-ch:
+				if !ok {
+					return
+				}
+				actual = append(actual, e)
+			}
+		}
+	}()
+	clientCh <- test.SubMessage{Msg: `{"appDeployLogs": {"timestamp": "2024-11-11T11:11:11Z", "text": "message 1"}}`}
+	clientCh <- test.SubMessage{Msg: `{"appDeployLogs": {"timestamp": "2024-11-11T11:11:22Z", "text": "message 2"}}`}
+	clientCh <- test.SubMessage{Msg: `{"appDeployLogs": {"timestamp": "2024-11-11T11:11:33Z", "text": "message 3"}}`}
+	close(clientCh)
+	wg.Wait()
+
+	expected := []AppDeployLogEntry{
+		{Timestamp: time.Date(2024, time.November, 11, 11, 11, 11, 0, time.UTC), Text: "message 1"},
+		{Timestamp: time.Date(2024, time.November, 11, 11, 11, 22, 0, time.UTC), Text: "message 2"},
+		{Timestamp: time.Date(2024, time.November, 11, 11, 11, 33, 0, time.UTC), Text: "message 3"},
+	}
+	if assert.NoError(t, err) {
+		assert.Equal(t, expected, actual)
+	}
+}

--- a/python/src/numerous/generated/graphql/__init__.py
+++ b/python/src/numerous/generated/graphql/__init__.py
@@ -48,6 +48,7 @@ from .fragments import (
 from .input_types import (
     AppCreateInfo,
     AppDeployInput,
+    AppDeployLogsInput,
     AppSecret,
     BuildPushInput,
     ElementInput,
@@ -97,6 +98,7 @@ __all__ = [
     "AllElementsSessionAllTextFieldGraphContext",
     "AppCreateInfo",
     "AppDeployInput",
+    "AppDeployLogsInput",
     "AppDeploymentStatus",
     "AppSecret",
     "AppSubscriptionStatus",

--- a/python/src/numerous/generated/graphql/input_types.py
+++ b/python/src/numerous/generated/graphql/input_types.py
@@ -35,6 +35,11 @@ class AppDeployInput(BaseModel):
     secrets: Optional[List["AppSecret"]] = None
 
 
+class AppDeployLogsInput(BaseModel):
+    organization_slug: str = Field(alias="organizationSlug")
+    app_name: str = Field(alias="appName")
+
+
 class SubscriptionOfferInput(BaseModel):
     email: str
     app_name: str = Field(alias="appName")

--- a/shared/schema.gql
+++ b/shared/schema.gql
@@ -314,6 +314,16 @@ type AppDeploymentStatusEvent {
 
 union AppDeployEvent = AppBuildMessageEvent | AppDeploymentStatusEvent | AppBuildErrorEvent
 
+input AppDeployLogsInput {
+    organizationSlug: String!
+    appName: String!
+}
+
+type AppDeployLogEntry {
+  timestamp: Time!
+  text: String!
+}
+
 extend type Query {
   app(organizationSlug: String!, appName: String!): App @hasRole(role: USER)
 }
@@ -329,6 +339,7 @@ extend type Mutation {
 
 extend type Subscription {
   appDeployEvents(appDeploymentVersionID: ID!): AppDeployEvent!
+  appDeployLogs(input: AppDeployLogsInput!): AppDeployLogEntry!
 }
 
 ###############################################################################
@@ -340,6 +351,7 @@ extend type Subscription {
 ###############################################################################
 
 directive @canAccessSubscriptionOffer on FIELD_DEFINITION
+directive @canManageSubscription on FIELD_DEFINITION
 
 enum SubscriptionOfferStatus {
   ACCEPTED
@@ -377,7 +389,15 @@ type SubscriptionOfferNotFound {
   id: ID!
 }
 
+type SubscriptionOfferInvalidStatus {
+  id: ID!
+}
+
 type AppSubscriptionNotFound {
+  id: ID!
+}
+
+type AppSubscriptionInvalidStatus {
   id: ID!
 }
 
@@ -388,8 +408,9 @@ union SubscriptionOfferResult = SubscriptionOffer | SubscriptionOfferNotFound
 union SubscriptionOfferAcceptResult =
     AppSubscription
   | SubscriptionOfferNotFound
+  | SubscriptionOfferInvalidStatus
 
-union AppSubscriptionResult = AppSubscription | AppSubscriptionNotFound
+union AppSubscriptionCancelResult = AppSubscription | AppSubscriptionNotFound | AppSubscriptionInvalidStatus
 
 extend type Organization {
   outboundSubscriptionOffers: [SubscriptionOffer!]!
@@ -418,8 +439,8 @@ extend type Mutation {
     @canAccessSubscriptionOffer
   subscriptionOfferWithdraw(subscriptionOfferId: ID!): SubscriptionOfferResult!
     @canAccessSubscriptionOffer
-  subscriptionCancel(subscriptionId: ID!): AppSubscriptionResult!
-    @hasRole(role: ADMIN)
+  subscriptionCancel(subscriptionId: ID!): AppSubscriptionCancelResult!
+    @canManageSubscription
 }
 
 ###############################################################################


### PR DESCRIPTION
Adds the command `numerous app logs` which prints the app logs from a deployment of an app.