### PR TITLE
feat(cli): add `app delete` command

### DIFF
--- a/cli/cmd/app/app.go
+++ b/cli/cmd/app/app.go
@@ -1,29 +1,21 @@
 package app
 
 import (
-	"os"
-
+	"numerous/cli/cmd/app/deletecmd"
 	"numerous/cli/cmd/app/deploy"
 	"numerous/cli/cmd/app/logs"
+	"numerous/cli/cmd/args"
 
 	"github.com/spf13/cobra"
 )
 
 var AppRootCmd = &cobra.Command{
-	Use: "app",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			if err := cmd.Help(); err != nil {
-				return err
-			}
-			os.Exit(0)
-		}
-
-		return nil
-	},
+	Use:  "app",
+	Args: args.SubCommandRequired,
 }
 
 func init() {
+	AppRootCmd.AddCommand(deletecmd.DeleteCmd)
 	AppRootCmd.AddCommand(deploy.DeployCmd)
 	AppRootCmd.AddCommand(logs.LogsCmd)
 }

--- a/cli/cmd/app/appident/errors.go
+++ b/cli/cmd/app/appident/errors.go
@@ -1,0 +1,8 @@
+package appident
+
+import "errors"
+
+var (
+	ErrInvalidSlug    = errors.New("invalid organization slug")
+	ErrInvalidAppName = errors.New("invalid app name")
+)

--- a/cli/cmd/app/appident/get_appidentifier.go
+++ b/cli/cmd/app/appident/get_appidentifier.go
@@ -1,0 +1,51 @@
+package appident
+
+import (
+	"path/filepath"
+
+	"numerous/cli/cmd/output"
+	"numerous/cli/cmd/validate"
+	"numerous/cli/manifest"
+)
+
+// Uses the given slug and appName, or loads from manifest, and validates.
+func GetAppIdentifier(appDir string, slug string, appName string) (string, string, error) {
+	if slug == "" && appName == "" {
+		manifest, err := manifest.LoadManifest(filepath.Join(appDir, manifest.ManifestPath))
+		if err != nil {
+			output.PrintErrorAppNotInitialized(appDir)
+
+			return "", "", err
+		}
+
+		if slug == "" && manifest.Deployment != nil {
+			slug = manifest.Deployment.OrganizationSlug
+		}
+
+		if appName == "" && manifest.Deployment != nil {
+			appName = manifest.Deployment.AppName
+		}
+	}
+
+	if !validate.IsValidIdentifier(slug) {
+		if slug == "" {
+			output.PrintErrorMissingOrganizationSlug()
+		} else {
+			output.PrintErrorInvalidOrganizationSlug(slug)
+		}
+
+		return "", "", ErrInvalidSlug
+	}
+
+	if !validate.IsValidIdentifier(appName) {
+		if appName == "" {
+			output.PrintErrorMissingAppName()
+		} else {
+			output.PrintErrorInvalidAppName(appName)
+		}
+
+		return "", "", ErrInvalidAppName
+	}
+
+	return slug, appName, nil
+}

--- a/cli/cmd/app/appident/get_appidentifier.go
+++ b/cli/cmd/app/appident/get_appidentifier.go
@@ -8,14 +8,19 @@ import (
 	"numerous/cli/manifest"
 )
 
+type AppIdentifier struct {
+	OrganizationSlug string
+	Name             string
+}
+
 // Uses the given slug and appName, or loads from manifest, and validates.
-func GetAppIdentifier(appDir string, slug string, appName string) (string, string, error) {
+func GetAppIdentifier(appDir string, slug string, appName string) (AppIdentifier, error) {
 	if slug == "" && appName == "" {
 		manifest, err := manifest.LoadManifest(filepath.Join(appDir, manifest.ManifestPath))
 		if err != nil {
 			output.PrintErrorAppNotInitialized(appDir)
 
-			return "", "", err
+			return AppIdentifier{}, err
 		}
 
 		if slug == "" && manifest.Deployment != nil {
@@ -34,7 +39,7 @@ func GetAppIdentifier(appDir string, slug string, appName string) (string, strin
 			output.PrintErrorInvalidOrganizationSlug(slug)
 		}
 
-		return "", "", ErrInvalidSlug
+		return AppIdentifier{}, ErrInvalidSlug
 	}
 
 	if !validate.IsValidIdentifier(appName) {
@@ -44,8 +49,8 @@ func GetAppIdentifier(appDir string, slug string, appName string) (string, strin
 			output.PrintErrorInvalidAppName(appName)
 		}
 
-		return "", "", ErrInvalidAppName
+		return AppIdentifier{}, ErrInvalidAppName
 	}
 
-	return slug, appName, nil
+	return AppIdentifier{OrganizationSlug: slug, Name: appName}, nil
 }

--- a/cli/cmd/app/appident/get_appidentifier_test.go
+++ b/cli/cmd/app/appident/get_appidentifier_test.go
@@ -30,7 +30,7 @@ func TestGetAppIdentifier(t *testing.T) {
 	t.Run("given invalid app name then invalid app name error is returned", func(t *testing.T) {
 		actual, err := GetAppIdentifier("", slug, "Some Invalid App Name")
 
-		assert.Equal(t, expected, actual)
+		assert.Equal(t, AppIdentifier{}, actual)
 		assert.ErrorIs(t, err, ErrInvalidAppName)
 	})
 

--- a/cli/cmd/app/appident/get_appidentifier_test.go
+++ b/cli/cmd/app/appident/get_appidentifier_test.go
@@ -11,28 +11,26 @@ import (
 func TestGetAppIdentifier(t *testing.T) {
 	const slug = "organization-slug"
 	const appName = "app-name"
+	expected := AppIdentifier{OrganizationSlug: slug, Name: appName}
 
 	t.Run("given valid slug and app name then they are returned", func(t *testing.T) {
-		actualSlug, actualAppName, err := GetAppIdentifier("", slug, appName)
+		actual, err := GetAppIdentifier("", slug, appName)
 
-		assert.Equal(t, slug, actualSlug)
-		assert.Equal(t, appName, actualAppName)
+		assert.Equal(t, expected, actual)
 		assert.NoError(t, err)
 	})
 
 	t.Run("given invalid slug then invalid slug error is returned", func(t *testing.T) {
-		actualSlug, actualAppName, err := GetAppIdentifier("", "Some Invalid Slug", appName)
+		appident, err := GetAppIdentifier("", "Some Invalid Slug", appName)
 
-		assert.Equal(t, "", actualSlug)
-		assert.Equal(t, "", actualAppName)
+		assert.Empty(t, appident)
 		assert.ErrorIs(t, err, ErrInvalidSlug)
 	})
 
 	t.Run("given invalid app name then invalid app name error is returned", func(t *testing.T) {
-		actualSlug, actualAppName, err := GetAppIdentifier("", slug, "Some Invalid App Name")
+		actual, err := GetAppIdentifier("", slug, "Some Invalid App Name")
 
-		assert.Equal(t, "", actualSlug)
-		assert.Equal(t, "", actualAppName)
+		assert.Equal(t, expected, actual)
 		assert.ErrorIs(t, err, ErrInvalidAppName)
 	})
 
@@ -40,10 +38,13 @@ func TestGetAppIdentifier(t *testing.T) {
 		appDir := t.TempDir()
 		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
 
-		actualSlug, actualAppName, err := GetAppIdentifier(appDir, "", "")
+		actual, err := GetAppIdentifier(appDir, "", "")
 
-		assert.Equal(t, "organization-slug-in-manifest", actualSlug)
-		assert.Equal(t, "app-name-in-manifest", actualAppName)
+		expected := AppIdentifier{
+			OrganizationSlug: "organization-slug-in-manifest",
+			Name:             "app-name-in-manifest",
+		}
+		assert.Equal(t, expected, actual)
 		assert.NoError(t, err)
 	})
 }

--- a/cli/cmd/app/appident/get_appidentifier_test.go
+++ b/cli/cmd/app/appident/get_appidentifier_test.go
@@ -1,0 +1,49 @@
+package appident
+
+import (
+	"testing"
+
+	"numerous/cli/test"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAppIdentifier(t *testing.T) {
+	const slug = "organization-slug"
+	const appName = "app-name"
+
+	t.Run("given valid slug and app name then they are returned", func(t *testing.T) {
+		actualSlug, actualAppName, err := GetAppIdentifier("", slug, appName)
+
+		assert.Equal(t, slug, actualSlug)
+		assert.Equal(t, appName, actualAppName)
+		assert.NoError(t, err)
+	})
+
+	t.Run("given invalid slug then invalid slug error is returned", func(t *testing.T) {
+		actualSlug, actualAppName, err := GetAppIdentifier("", "Some Invalid Slug", appName)
+
+		assert.Equal(t, "", actualSlug)
+		assert.Equal(t, "", actualAppName)
+		assert.ErrorIs(t, err, ErrInvalidSlug)
+	})
+
+	t.Run("given invalid app name then invalid app name error is returned", func(t *testing.T) {
+		actualSlug, actualAppName, err := GetAppIdentifier("", slug, "Some Invalid App Name")
+
+		assert.Equal(t, "", actualSlug)
+		assert.Equal(t, "", actualAppName)
+		assert.ErrorIs(t, err, ErrInvalidAppName)
+	})
+
+	t.Run("given app dir but no slug and no app name then it is loaded from manifest", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
+
+		actualSlug, actualAppName, err := GetAppIdentifier(appDir, "", "")
+
+		assert.Equal(t, "organization-slug-in-manifest", actualSlug)
+		assert.Equal(t, "app-name-in-manifest", actualAppName)
+		assert.NoError(t, err)
+	})
+}

--- a/cli/cmd/app/deletecmd/cmd.go
+++ b/cli/cmd/app/deletecmd/cmd.go
@@ -1,0 +1,60 @@
+package deletecmd
+
+import (
+	"net/http"
+	"os"
+
+	"numerous/cli/cmd/args"
+	"numerous/cli/internal/app"
+	"numerous/cli/internal/gql"
+
+	"github.com/spf13/cobra"
+)
+
+var DeleteCmd = &cobra.Command{
+	Use:   "delete [app directory]",
+	Run:   run,
+	Short: "Delete an app from an organization.",
+	Long: `Deletes the specified app from the organization.
+
+If <name> and <organization> flags are set, they define the app to delete. If
+they are not the default deployment section in the manifest is used if it is
+defined.
+
+If [app directory] is specified, that directory will be used to read the
+app manifest for the default deployment information.
+
+If no [app directory] is specified, the current working directory is used.`,
+	Example: `To delete an app use the following form:
+
+    numerous app delete --organization "organization-slug-a2ecf59b" --name "my-app"
+
+Otherwise, assuming an app has been initialized in the directory
+"my_project/my_app" and has a default deployment defined in its manifest:
+
+    numerous app delete my_project/my_app
+`,
+	Args: args.OptionalAppDir(&appDir),
+}
+
+var (
+	slug    string
+	appName string
+	appDir  string = "."
+)
+
+func run(cmd *cobra.Command, args []string) {
+	service := app.New(gql.NewClient(), nil, http.DefaultClient)
+
+	if err := Delete(cmd.Context(), service, appDir, slug, appName); err != nil {
+		os.Exit(1)
+	} else {
+		os.Exit(0)
+	}
+}
+
+func init() {
+	flags := DeleteCmd.Flags()
+	flags.StringVarP(&slug, "organization", "o", "", "The organization slug identifier of the app to read logs from.")
+	flags.StringVarP(&appName, "name", "n", "", "The name of the app to read logs from.")
+}

--- a/cli/cmd/app/deletecmd/cmd.go
+++ b/cli/cmd/app/deletecmd/cmd.go
@@ -2,7 +2,6 @@ package deletecmd
 
 import (
 	"net/http"
-	"os"
 
 	"numerous/cli/cmd/args"
 	"numerous/cli/internal/app"
@@ -13,7 +12,7 @@ import (
 
 var DeleteCmd = &cobra.Command{
 	Use:   "delete [app directory]",
-	Run:   run,
+	RunE:  run,
 	Short: "Delete an app from an organization.",
 	Long: `Deletes the specified app from the organization.
 
@@ -43,14 +42,9 @@ var (
 	appDir  string = "."
 )
 
-func run(cmd *cobra.Command, args []string) {
+func run(cmd *cobra.Command, args []string) error {
 	service := app.New(gql.NewClient(), nil, http.DefaultClient)
-
-	if err := Delete(cmd.Context(), service, appDir, slug, appName); err != nil {
-		os.Exit(1)
-	} else {
-		os.Exit(0)
-	}
+	return Delete(cmd.Context(), service, appDir, slug, appName)
 }
 
 func init() {

--- a/cli/cmd/app/deletecmd/delete.go
+++ b/cli/cmd/app/deletecmd/delete.go
@@ -1,0 +1,30 @@
+package deletecmd
+
+import (
+	"context"
+
+	"numerous/cli/cmd/app/appident"
+	"numerous/cli/cmd/output"
+	"numerous/cli/internal/app"
+)
+
+type AppService interface {
+	Delete(ctx context.Context, input app.DeleteAppInput) error
+}
+
+func Delete(ctx context.Context, apps AppService, appDir, slug, appName string) error {
+	slug, appName, err := appident.GetAppIdentifier(appDir, slug, appName)
+	if err != nil {
+		return err
+	}
+
+	err = apps.Delete(ctx, app.DeleteAppInput{OrganizationSlug: slug, Name: appName})
+	if err != nil {
+		output.PrintErrorDetails("Error occurred deleting app.", err)
+		return err
+	}
+
+	output.PrintlnOK("Deleted app %s/%s", slug, appName)
+
+	return nil
+}

--- a/cli/cmd/app/deletecmd/delete.go
+++ b/cli/cmd/app/deletecmd/delete.go
@@ -13,12 +13,12 @@ type AppService interface {
 }
 
 func Delete(ctx context.Context, apps AppService, appDir, slug, appName string) error {
-	slug, appName, err := appident.GetAppIdentifier(appDir, slug, appName)
+	ai, err := appident.GetAppIdentifier(appDir, slug, appName)
 	if err != nil {
 		return err
 	}
 
-	err = apps.Delete(ctx, app.DeleteAppInput{OrganizationSlug: slug, Name: appName})
+	err = apps.Delete(ctx, app.DeleteAppInput(ai))
 	if err != nil {
 		output.PrintErrorDetails("Error occurred deleting app.", err)
 		return err

--- a/cli/cmd/app/deletecmd/delete_test.go
+++ b/cli/cmd/app/deletecmd/delete_test.go
@@ -1,0 +1,54 @@
+package deletecmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"numerous/cli/internal/app"
+	"numerous/cli/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestDelete(t *testing.T) {
+	const appName = "app-name"
+	const slug = "organization-slug"
+	testError := errors.New("test error")
+
+	t.Run("given app with manifest then it deletes expected app", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../../testdata/streamlit_app", appDir)
+		service := &MockAppService{}
+
+		expectedInput := app.DeleteAppInput{OrganizationSlug: "organization-slug-in-manifest", Name: "app-name-in-manifest"}
+		service.On("Delete", mock.Anything, expectedInput).Return(nil)
+
+		err := Delete(context.TODO(), service, appDir, "", "")
+		assert.NoError(t, err)
+	})
+
+	t.Run("given slug and app name arguments then it deletes expected app", func(t *testing.T) {
+		appDir := t.TempDir()
+		service := &MockAppService{}
+
+		expectedInput := app.DeleteAppInput{OrganizationSlug: slug, Name: appName}
+		service.On("Delete", mock.Anything, expectedInput).Return(nil)
+
+		err := Delete(context.TODO(), service, appDir, slug, appName)
+		assert.NoError(t, err)
+	})
+
+	t.Run("given error is returned then it passes the error on", func(t *testing.T) {
+		appDir := t.TempDir()
+		service := &MockAppService{}
+
+		expectedInput := app.DeleteAppInput{OrganizationSlug: slug, Name: appName}
+		service.On("Delete", mock.Anything, expectedInput).Return(testError)
+
+		err := Delete(context.TODO(), service, appDir, slug, appName)
+
+		assert.ErrorIs(t, err, testError)
+	})
+}

--- a/cli/cmd/app/deletecmd/mock.go
+++ b/cli/cmd/app/deletecmd/mock.go
@@ -1,0 +1,21 @@
+package deletecmd
+
+import (
+	"context"
+
+	"numerous/cli/internal/app"
+
+	"github.com/stretchr/testify/mock"
+)
+
+var _ AppService = &MockAppService{}
+
+type MockAppService struct {
+	mock.Mock
+}
+
+// Delete implements AppService.
+func (m *MockAppService) Delete(ctx context.Context, input app.DeleteAppInput) error {
+	args := m.Called(ctx, input)
+	return args.Error(0)
+}

--- a/cli/cmd/app/deploy/cmd.go
+++ b/cli/cmd/app/deploy/cmd.go
@@ -1,10 +1,10 @@
 package deploy
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 
+	"numerous/cli/cmd/args"
 	"numerous/cli/internal/app"
 	"numerous/cli/internal/gql"
 
@@ -34,20 +34,7 @@ be pushed to the organization "organization-slug-a2ecf59b", and the app name
 
 	numerous app deploy --organization "organization-slug-a2ecf59b" --name "my-app"
 	`,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			fn := cmd.HelpFunc()
-			fn(cmd, args)
-
-			return fmt.Errorf("accepts only an optional [app directory] as a positional argument, you provided %d arguments", len(args))
-		}
-
-		if len(args) == 1 {
-			appDir = args[0]
-		}
-
-		return nil
-	},
+	Args: args.OptionalAppDir(&appDir),
 }
 
 var (

--- a/cli/cmd/app/logs/cmd.go
+++ b/cli/cmd/app/logs/cmd.go
@@ -1,10 +1,10 @@
 package logs
 
 import (
-	"fmt"
 	"net/http"
 	"os"
 
+	"numerous/cli/cmd/args"
 	"numerous/cli/internal/app"
 	"numerous/cli/internal/gql"
 
@@ -35,20 +35,7 @@ Otherwise, assuming an app has been initialized in the directory
 
     numerous app logs my_project/my_app
 `,
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) > 1 {
-			fn := cmd.HelpFunc()
-			fn(cmd, args)
-
-			return fmt.Errorf("accepts only an optional [app directory] as a positional argument, you provided %d arguments", len(args))
-		}
-
-		if len(args) == 1 {
-			appDir = args[0]
-		}
-
-		return nil
-	},
+	Args: args.OptionalAppDir(&appDir),
 }
 
 var (

--- a/cli/cmd/app/logs/logs.go
+++ b/cli/cmd/app/logs/logs.go
@@ -11,16 +11,16 @@ import (
 )
 
 type AppService interface {
-	AppDeployLogs(slug, appName string) (chan app.AppDeployLogEntry, error)
+	AppDeployLogs(appident.AppIdentifier) (chan app.AppDeployLogEntry, error)
 }
 
 func Logs(ctx context.Context, apps AppService, appDir, slug, appName string, printer func(app.AppDeployLogEntry)) error {
-	slug, appName, err := appident.GetAppIdentifier(appDir, slug, appName)
+	ai, err := appident.GetAppIdentifier(appDir, slug, appName)
 	if err != nil {
 		return err
 	}
 
-	ch, err := apps.AppDeployLogs(slug, appName)
+	ch, err := apps.AppDeployLogs(ai)
 	if err != nil {
 		return err
 	}

--- a/cli/cmd/app/logs/logs_test.go
+++ b/cli/cmd/app/logs/logs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"numerous/cli/cmd/app/appident"
 	"numerous/cli/internal/app"
 	"numerous/cli/test"
 
@@ -22,13 +23,13 @@ func TestLogs(t *testing.T) {
 	t.Run("given invalid slug then it returns error", func(t *testing.T) {
 		err := Logs(context.TODO(), nil, appDir, "Some Invalid Organization Slug", appName, dummyPrinter)
 
-		assert.ErrorIs(t, err, ErrInvalidSlug)
+		assert.ErrorIs(t, err, appident.ErrInvalidSlug)
 	})
 
 	t.Run("given invalid app name then it returns error", func(t *testing.T) {
 		err := Logs(context.TODO(), nil, appDir, slug, "Some Invalid App Name", dummyPrinter)
 
-		assert.ErrorIs(t, err, ErrInvalidAppName)
+		assert.ErrorIs(t, err, appident.ErrInvalidAppName)
 	})
 
 	t.Run("given neither slug nor app name arguments and numerous.toml without deploy then it returns error", func(t *testing.T) {
@@ -37,7 +38,7 @@ func TestLogs(t *testing.T) {
 
 		err := Logs(context.TODO(), nil, appDir, "", "", dummyPrinter)
 
-		assert.ErrorIs(t, err, ErrInvalidSlug)
+		assert.ErrorIs(t, err, appident.ErrInvalidSlug)
 	})
 
 	t.Run("given no slug and app name arguments and app dir without numerous.toml then it returns error", func(t *testing.T) {

--- a/cli/cmd/app/logs/mock.go
+++ b/cli/cmd/app/logs/mock.go
@@ -1,6 +1,7 @@
 package logs
 
 import (
+	"numerous/cli/cmd/app/appident"
 	"numerous/cli/internal/app"
 
 	"github.com/stretchr/testify/mock"
@@ -13,7 +14,7 @@ type AppServiceMock struct {
 }
 
 // AppDeployLogs implements AppService.
-func (m *AppServiceMock) AppDeployLogs(slug string, appName string) (chan app.AppDeployLogEntry, error) {
-	args := m.Called(slug, appName)
+func (m *AppServiceMock) AppDeployLogs(ai appident.AppIdentifier) (chan app.AppDeployLogEntry, error) {
+	args := m.Called(ai)
 	return args.Get(0).(chan app.AppDeployLogEntry), args.Error(1)
 }

--- a/cli/cmd/args/appdir.go
+++ b/cli/cmd/args/appdir.go
@@ -1,0 +1,26 @@
+package args
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// Returns an arguments handler, which checks an optional app dir positional
+// argument, and writes it into the given string reference.
+func OptionalAppDir(appDir *string) func(cmd *cobra.Command, args []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if len(args) > 1 {
+			fn := cmd.HelpFunc()
+			fn(cmd, args)
+
+			return fmt.Errorf("accepts only an optional [app directory] as a positional argument, you provided %d arguments", len(args))
+		}
+
+		if len(args) == 1 {
+			*appDir = args[0]
+		}
+
+		return nil
+	}
+}

--- a/cli/cmd/args/appdir_test.go
+++ b/cli/cmd/args/appdir_test.go
@@ -1,0 +1,36 @@
+package args
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionalAppDir(t *testing.T) {
+	t.Run("given single argument then it updates the variable", func(t *testing.T) {
+		var appDir string
+
+		err := OptionalAppDir(&appDir)(nil, []string{"some-app-dir"})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "some-app-dir", appDir)
+	})
+
+	t.Run("given zero arguments then it does not update the variable", func(t *testing.T) {
+		appDir := "some-preexisting-value"
+
+		err := OptionalAppDir(&appDir)(nil, []string{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "some-preexisting-value", appDir)
+	})
+
+	t.Run("given more than one argument then it returns an error", func(t *testing.T) {
+		var appDir string
+
+		err := OptionalAppDir(&appDir)(&cobra.Command{}, []string{"arg1", "arg2", "arg3"})
+
+		assert.EqualError(t, err, "accepts only an optional [app directory] as a positional argument, you provided 3 arguments")
+	})
+}

--- a/cli/cmd/args/subcmd.go
+++ b/cli/cmd/args/subcmd.go
@@ -1,0 +1,15 @@
+package args
+
+import (
+	"flag"
+
+	"github.com/spf13/cobra"
+)
+
+func SubCommandRequired(cmd *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return flag.ErrHelp
+	}
+
+	return nil
+}

--- a/cli/cmd/args/subcmd_test.go
+++ b/cli/cmd/args/subcmd_test.go
@@ -1,0 +1,23 @@
+package args
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubCommandRequired(t *testing.T) {
+	t.Run("given no arguments then it returns ErrHelp", func(t *testing.T) {
+		err := SubCommandRequired(&cobra.Command{}, []string{})
+
+		assert.ErrorIs(t, err, flag.ErrHelp)
+	})
+
+	t.Run("given an argument it returns no error", func(t *testing.T) {
+		err := SubCommandRequired(&cobra.Command{}, []string{"subcmd"})
+
+		assert.NoError(t, err)
+	})
+}

--- a/cli/cmd/organization/organization.go
+++ b/cli/cmd/organization/organization.go
@@ -1,8 +1,7 @@
 package organization
 
 import (
-	"os"
-
+	"numerous/cli/cmd/args"
 	"numerous/cli/cmd/organization/create"
 	"numerous/cli/cmd/organization/list"
 
@@ -10,17 +9,8 @@ import (
 )
 
 var OrganizationRootCmd = &cobra.Command{
-	Use: "organization",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			if err := cmd.Help(); err != nil {
-				return err
-			}
-			os.Exit(0)
-		}
-
-		return nil
-	},
+	Use:  "organization",
+	Args: args.SubCommandRequired,
 }
 
 func init() {

--- a/cli/internal/app/app_delete.go
+++ b/cli/internal/app/app_delete.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	"context"
+
+	"numerous/cli/internal/gql"
+)
+
+const deleteMutation string = `
+	mutation DeleteApp($slug: String!, $name: String!) {
+		appDelete(input: {organizationSlug: $slug, appName: $name}) {
+			__typename
+		}
+	}
+`
+
+type deleteAppResponse struct {
+	AppDelete struct {
+		Typename string `graphql:"__typename"`
+	}
+}
+
+type DeleteAppInput struct {
+	OrganizationSlug string
+	Name             string
+}
+
+func (s *Service) Delete(ctx context.Context, input DeleteAppInput) error {
+	resp := deleteAppResponse{}
+	vars := map[string]any{"slug": input.OrganizationSlug, "name": input.Name}
+
+	err := s.client.Exec(ctx, deleteMutation, &resp, vars)
+	if err != nil {
+		return gql.CheckAccessDenied(err)
+	}
+
+	return nil
+}

--- a/cli/internal/app/app_delete_test.go
+++ b/cli/internal/app/app_delete_test.go
@@ -38,7 +38,7 @@ func TestAppDelete(t *testing.T) {
 		assert.ErrorIs(t, err, gql.ErrAccesDenied)
 	})
 
-	t.Run("given graphql error then it returns access denied error", func(t *testing.T) {
+	t.Run("given graphql error then it returns given graphql error", func(t *testing.T) {
 		doer := test.MockDoer{}
 		c := test.CreateTestGQLClient(t, &doer)
 		s := New(c, nil, nil)

--- a/cli/internal/app/app_delete_test.go
+++ b/cli/internal/app/app_delete_test.go
@@ -1,0 +1,92 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"numerous/cli/internal/gql"
+	"numerous/cli/test"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAppDelete(t *testing.T) {
+	t.Run("given access denied then it returns access denied error", func(t *testing.T) {
+		doer := test.MockDoer{}
+		c := test.CreateTestGQLClient(t, &doer)
+		s := New(c, nil, nil)
+
+		respBody := `
+			{
+				"errors": [{
+					"message": "access denied",
+					"location": [{"line": 1, "column": 1}],
+					"path": ["app"]
+				}]
+			}
+		`
+		resp := test.JSONResponse(respBody)
+		doer.On("Do", mock.Anything).Return(resp, nil)
+
+		input := DeleteAppInput{
+			OrganizationSlug: "organization-slug",
+			Name:             "app-name",
+		}
+		err := s.Delete(context.TODO(), input)
+
+		assert.ErrorIs(t, err, gql.ErrAccesDenied)
+	})
+
+	t.Run("given graphql error then it returns access denied error", func(t *testing.T) {
+		doer := test.MockDoer{}
+		c := test.CreateTestGQLClient(t, &doer)
+		s := New(c, nil, nil)
+
+		respBody := `
+			{
+				"errors": [{
+					"message": "expected error message",
+					"location": [{"line": 1, "column": 1}],
+					"path": ["app"]
+				}]
+			}
+		`
+		resp := test.JSONResponse(respBody)
+		doer.On("Do", mock.Anything).Return(resp, nil)
+
+		input := DeleteAppInput{
+			OrganizationSlug: "organization-slug",
+			Name:             "app-name",
+		}
+		err := s.Delete(context.TODO(), input)
+
+		assert.ErrorContains(t, err, "expected error message")
+	})
+
+	t.Run("given successful response it returns no error", func(t *testing.T) {
+		doer := test.MockDoer{}
+		c := test.CreateTestGQLClient(t, &doer)
+		s := New(c, nil, nil)
+
+		respBody := `
+			{
+				"data": {
+					"appDelete": {
+						"__typename": "AppDeleted"
+					}
+				}
+			}
+		`
+		resp := test.JSONResponse(respBody)
+		doer.On("Do", mock.Anything).Return(resp, nil)
+
+		input := DeleteAppInput{
+			OrganizationSlug: "organization-slug",
+			Name:             "app-name",
+		}
+		err := s.Delete(context.TODO(), input)
+
+		assert.NoError(t, err)
+	})
+}

--- a/cli/internal/app/app_deploy_logs.go
+++ b/cli/internal/app/app_deploy_logs.go
@@ -3,6 +3,8 @@ package app
 import (
 	"time"
 
+	"numerous/cli/cmd/app/appident"
+
 	"github.com/hasura/go-graphql-client/pkg/jsonutil"
 )
 
@@ -15,7 +17,7 @@ type AppDeployLogsSubscription struct {
 	AppDeployLogs AppDeployLogEntry `graphql:"appDeployLogs(input: {organizationSlug: $slug, appName: $name})"`
 }
 
-func (s *Service) AppDeployLogs(slug, name string) (chan AppDeployLogEntry, error) {
+func (s *Service) AppDeployLogs(ai appident.AppIdentifier) (chan AppDeployLogEntry, error) {
 	ch := make(chan AppDeployLogEntry)
 
 	handler := func(message []byte, err error) error {
@@ -36,8 +38,8 @@ func (s *Service) AppDeployLogs(slug, name string) (chan AppDeployLogEntry, erro
 	}
 
 	vars := make(map[string]any)
-	vars["slug"] = slug
-	vars["name"] = name
+	vars["slug"] = ai.OrganizationSlug
+	vars["name"] = ai.Name
 	_, err := s.subscription.Subscribe(&AppDeployLogsSubscription{}, vars, handler)
 	if err != nil {
 		return nil, err

--- a/cli/internal/app/app_deploy_logs_test.go
+++ b/cli/internal/app/app_deploy_logs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"numerous/cli/cmd/app/appident"
 	"numerous/cli/test"
 
 	"github.com/stretchr/testify/assert"
@@ -15,7 +16,7 @@ func TestAppDeployLogs(t *testing.T) {
 	c := test.CreateTestSubscriptionClient(t, clientCh)
 	s := New(nil, c, nil)
 
-	ch, err := s.AppDeployLogs("organization-slug", "app-name")
+	ch, err := s.AppDeployLogs(appident.AppIdentifier{OrganizationSlug: "organization-slug", Name: "app-name"})
 
 	wg := &sync.WaitGroup{}
 	wg.Add(1)

--- a/python/src/numerous/generated/graphql/__init__.py
+++ b/python/src/numerous/generated/graphql/__init__.py
@@ -47,6 +47,7 @@ from .fragments import (
 )
 from .input_types import (
     AppCreateInfo,
+    AppDeleteInput,
     AppDeployInput,
     AppDeployLogsInput,
     AppSecret,
@@ -97,6 +98,7 @@ __all__ = [
     "AllElementsSessionAllTextField",
     "AllElementsSessionAllTextFieldGraphContext",
     "AppCreateInfo",
+    "AppDeleteInput",
     "AppDeployInput",
     "AppDeployLogsInput",
     "AppDeploymentStatus",

--- a/python/src/numerous/generated/graphql/input_types.py
+++ b/python/src/numerous/generated/graphql/input_types.py
@@ -40,6 +40,11 @@ class AppDeployLogsInput(BaseModel):
     app_name: str = Field(alias="appName")
 
 
+class AppDeleteInput(BaseModel):
+    app_name: str = Field(alias="appName")
+    organization_slug: str = Field(alias="organizationSlug")
+
+
 class SubscriptionOfferInput(BaseModel):
     email: str
     app_name: str = Field(alias="appName")

--- a/shared/schema.gql
+++ b/shared/schema.gql
@@ -425,7 +425,7 @@ union AppSubscriptionCancelResult = AppSubscription | AppSubscriptionNotFound | 
 
 extend type Organization {
   outboundSubscriptionOffers: [SubscriptionOffer!]! @hasRole(role: ADMIN)
-  outboundSubscriptions: [AppSubscription!]!
+  outboundSubscriptions: [AppSubscription!]! @hasRole(role: ADMIN)
 }
 
 extend type App {

--- a/shared/schema.gql
+++ b/shared/schema.gql
@@ -324,6 +324,16 @@ type AppDeployLogEntry {
   text: String!
 }
 
+type AppDeleted {
+    appName: String!
+    organizationSlug: String
+}
+
+input AppDeleteInput {
+    appName: String!
+    organizationSlug: String!
+}
+
 extend type Query {
   app(organizationSlug: String!, appName: String!): App @hasRole(role: USER)
 }
@@ -335,6 +345,7 @@ extend type Mutation {
   appVersionUploadURL(appVersionID: ID!): AppVersionUploadURL! @canManageApp
   appDeploy(appVersionID: ID!, input: AppDeployInput): AppDeploymentVersion!
     @canManageApp
+  appDelete(input: AppDeleteInput!): AppDeleted! @canManageApp
 }
 
 extend type Subscription {
@@ -413,7 +424,7 @@ union SubscriptionOfferAcceptResult =
 union AppSubscriptionCancelResult = AppSubscription | AppSubscriptionNotFound | AppSubscriptionInvalidStatus
 
 extend type Organization {
-  outboundSubscriptionOffers: [SubscriptionOffer!]!
+  outboundSubscriptionOffers: [SubscriptionOffer!]! @hasRole(role: ADMIN)
   outboundSubscriptions: [AppSubscription!]!
 }
 


### PR DESCRIPTION
Adds the command `numerous app delete` which deletes an app from Numerous, all associated information, and stops all related workloads.