### PR TITLE
fix(cli): `init` command error printing improvements

### DIFF
--- a/cmd/initialize/cmd.go
+++ b/cmd/initialize/cmd.go
@@ -38,7 +38,6 @@ var (
 func run(cmd *cobra.Command, args []string) error {
 	appDir, m, err := PrepareInit(args)
 	if err != nil {
-		output.PrintErrorDetails("An error occurred preparing app initialization", err)
 		return err
 	}
 

--- a/cmd/initialize/wizard/folder.go
+++ b/cmd/initialize/wizard/folder.go
@@ -52,7 +52,9 @@ func confirmFolderSurvey(folderPath string, in terminal.FileReader) (bool, error
 	msg := fmt.Sprintf("Use the existing folder %s for your app? (default: yes)", folderPath)
 	prompt := &survey.Confirm{Message: msg, Default: true}
 	err := survey.AskOne(prompt, &confirm, func(options *survey.AskOptions) error { options.Stdio.In = in; return nil })
-	if err != nil {
+	if errors.Is(err, terminal.InterruptErr) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
 

--- a/cmd/initialize/wizard/wizard.go
+++ b/cmd/initialize/wizard/wizard.go
@@ -1,12 +1,14 @@
 package wizard
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"numerous.com/cli/internal/manifest"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 )
 
 type InitWizardOptions struct {
@@ -35,7 +37,9 @@ func RunInitAppWizard(projectFolderPath string, m *manifest.Manifest) (bool, err
 	}
 
 	answers := answersFromManifest(m)
-	if err := survey.Ask(questions, &answers); err != nil {
+	if err := survey.Ask(questions, &answers); errors.Is(err, terminal.InterruptErr) {
+		return false, nil
+	} else if err != nil {
 		return false, err
 	}
 


### PR DESCRIPTION
* Do not print initialization preparation errors twice for the non-legacy command.
* Do not print interrupts as errors.