### PR TITLE
fix(cli): streamline error output

### DIFF
--- a/cmd/deploy/cmd.go
+++ b/cmd/deploy/cmd.go
@@ -61,8 +61,9 @@ func run(cmd *cobra.Command, args []string) error {
 		Version:    version,
 		Verbose:    verbose,
 	}
+	err := Deploy(cmd.Context(), service, input)
 
-	return errorhandling.ErrorAlreadyPrinted(Deploy(cmd.Context(), service, input))
+	return errorhandling.ErrorAlreadyPrinted(err)
 }
 
 func init() {

--- a/cmd/deploy/cmd.go
+++ b/cmd/deploy/cmd.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"numerous.com/cli/cmd/args"
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/group"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/gql"
@@ -61,7 +62,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Verbose:    verbose,
 	}
 
-	return Deploy(cmd.Context(), service, input)
+	return errorhandling.ErrorAlreadyPrinted(Deploy(cmd.Context(), service, input))
 }
 
 func init() {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -85,7 +85,9 @@ func loadAppConfiguration(input DeployInput) (*manifest.Manifest, map[string]str
 	// for validation
 	ai, err := appident.GetAppIdentifier(input.AppDir, m, input.OrgSlug, input.AppSlug)
 	if err != nil {
+		task.Error()
 		output.PrintGetAppIdentiferError(err, input.AppDir, ai)
+
 		return nil, nil, err
 	}
 

--- a/cmd/errorhandling/errors.go
+++ b/cmd/errorhandling/errors.go
@@ -1,0 +1,14 @@
+package errorhandling
+
+import "errors"
+
+// Used to signal that an error occurred, but it should not be printed
+var ErrAlreadyPrinted = errors.New("represents an error that was printed previously")
+
+func ErrorAlreadyPrinted(err error) error {
+	if err == nil {
+		return nil
+	} else {
+		return ErrAlreadyPrinted
+	}
+}

--- a/cmd/legacy/delete/delete.go
+++ b/cmd/legacy/delete/delete.go
@@ -20,7 +20,8 @@ var DeleteCmd = &cobra.Command{
 	Long: `Removes the app from the server and deletes any associated resources, such as docker images or containers.
 This action cannot be undone.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errorhandling.ErrorAlreadyPrinted(deleteApp(gql.GetClient(), args))
+		err := deleteApp(gql.GetClient(), args)
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 

--- a/cmd/legacy/delete/delete.go
+++ b/cmd/legacy/delete/delete.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/dir"
 	"numerous.com/cli/internal/gql"
@@ -19,7 +20,7 @@ var DeleteCmd = &cobra.Command{
 	Long: `Removes the app from the server and deletes any associated resources, such as docker images or containers.
 This action cannot be undone.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteApp(gql.GetClient(), args)
+		return errorhandling.ErrorAlreadyPrinted(deleteApp(gql.GetClient(), args))
 	},
 }
 

--- a/cmd/legacy/list/list.go
+++ b/cmd/legacy/list/list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/auth"
 	"numerous.com/cli/internal/gql"
@@ -17,11 +18,7 @@ var ListCmd = &cobra.Command{
 	Short: "List all your apps (login required)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := list(auth.NumerousTenantAuthenticator, gql.GetClient())
-		if err != nil {
-			output.PrintUnknownError(err)
-		}
-
-		return err
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 

--- a/cmd/legacy/publish/publish.go
+++ b/cmd/legacy/publish/publish.go
@@ -3,6 +3,7 @@ package publish
 import (
 	"fmt"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/dir"
 	"numerous.com/cli/internal/gql"
@@ -17,11 +18,7 @@ var PublishCmd = &cobra.Command{
 	Short: "Publishes an app to the public app gallery",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := publish(gql.GetClient())
-		if err != nil {
-			return err
-		}
-
-		return nil
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 

--- a/cmd/legacy/push/push.go
+++ b/cmd/legacy/push/push.go
@@ -41,7 +41,8 @@ var PushCmd = &cobra.Command{
 builds a docker image and runs it as a container.
 A URL is generated which provides access to the tool, anyone with the URL can access the tool.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return errorhandling.ErrorAlreadyPrinted(push(cmd, args))
+		err := push(args)
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 
@@ -53,7 +54,7 @@ class MyApp:
 
 appdef = MyApp`
 
-func push(cmd *cobra.Command, args []string) error {
+func push(args []string) error {
 	appDir, projectDir, appPath, err := parseArguments(args)
 	if err != nil {
 		return err

--- a/cmd/legacy/push/push.go
+++ b/cmd/legacy/push/push.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"numerous.com/cli/cmd/errorhandling"
 	cmdinit "numerous.com/cli/cmd/init"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/archive"
@@ -39,7 +40,9 @@ var PushCmd = &cobra.Command{
 	Long: `Zip-compresses the tool project and pushes it to the numerous server, which
 builds a docker image and runs it as a container.
 A URL is generated which provides access to the tool, anyone with the URL can access the tool.`,
-	RunE: run,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return errorhandling.ErrorAlreadyPrinted(push(cmd, args))
+	},
 }
 
 var numerousAppEngineMsg string = `You can solve this by assigning your app definition to this name, for example:
@@ -50,7 +53,7 @@ class MyApp:
 
 appdef = MyApp`
 
-func run(cmd *cobra.Command, args []string) error {
+func push(cmd *cobra.Command, args []string) error {
 	appDir, projectDir, appPath, err := parseArguments(args)
 	if err != nil {
 		return err

--- a/cmd/legacy/unpublish/unpublish.go
+++ b/cmd/legacy/unpublish/unpublish.go
@@ -3,6 +3,7 @@ package unpublish
 import (
 	"fmt"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/dir"
 	"numerous.com/cli/internal/gql"
@@ -17,11 +18,7 @@ var UnpublishCmd = &cobra.Command{
 	Short: "Removes a published app from the public app gallery",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := unpublish(gql.GetClient())
-		if err != nil {
-			output.PrintErrorDetails("Error unpublishing app", err)
-		}
-
-		return err
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/group"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/auth"
@@ -24,9 +25,9 @@ var LoginCmd = &cobra.Command{
 			return nil
 		}
 
-		_, err := Login(auth.NumerousTenantAuthenticator, cmd.Context())
+		_, err := login(auth.NumerousTenantAuthenticator, cmd.Context())
 
-		return err
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 
@@ -42,7 +43,7 @@ Verification code: %s
 Press Enter to continue...
 `
 
-func Login(a auth.Authenticator, ctx context.Context) (*auth.User, error) {
+func login(a auth.Authenticator, ctx context.Context) (*auth.User, error) {
 	state, err := a.GetDeviceCode(ctx, http.DefaultClient)
 	if err != nil {
 		output.PrintErrorDetails("Error getting device code", err)

--- a/cmd/login/login_test.go
+++ b/cmd/login/login_test.go
@@ -51,7 +51,7 @@ func TestLogin(t *testing.T) {
 		RefreshToken: result.RefreshToken,
 		Tenant:       testTenant,
 	})
-	acutalUser, _ := Login(m, context.Background())
+	acutalUser, _ := login(m, context.Background())
 
 	m.AssertExpectations(t)
 	assert.Equal(t, expectedUser, acutalUser)

--- a/cmd/logout/logout.go
+++ b/cmd/logout/logout.go
@@ -3,6 +3,7 @@ package logout
 import (
 	"net/http"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/group"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/auth"
@@ -14,11 +15,10 @@ var LogoutCmd = &cobra.Command{
 	Use:     "logout",
 	Short:   "Logout of the Numerous CLI",
 	GroupID: group.AdditionalCommandsGroupID,
-	RunE:    run,
-}
-
-func run(cmd *cobra.Command, args []string) error {
-	return logout(auth.NumerousTenantAuthenticator)
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := logout(auth.NumerousTenantAuthenticator)
+		return errorhandling.ErrorAlreadyPrinted(err)
+	},
 }
 
 func logout(a auth.Authenticator) error {

--- a/cmd/logs/cmd.go
+++ b/cmd/logs/cmd.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"numerous.com/cli/cmd/args"
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/group"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/app"
@@ -65,8 +66,9 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	sc := gql.NewSubscriptionClient().WithSyncMode(true)
 	service := app.New(gql.NewClient(), sc, http.DefaultClient)
+	err := Logs(cmd.Context(), service, appDir, orgSlug, appSlug, printer)
 
-	return Logs(cmd.Context(), service, appDir, orgSlug, appSlug, printer)
+	return errorhandling.ErrorAlreadyPrinted(err)
 }
 
 func init() {

--- a/cmd/organization/create/organization_create.go
+++ b/cmd/organization/create/organization_create.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/organization/create/wizard"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/auth"
@@ -25,7 +26,7 @@ var OrganizationCreateCmd = &cobra.Command{
 			output.PrintErrorDetails("Error creating organization", err)
 		}
 
-		return err
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 

--- a/cmd/organization/list/organization_list.go
+++ b/cmd/organization/list/organization_list.go
@@ -3,6 +3,7 @@ package list
 import (
 	"fmt"
 
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/auth"
 	"numerous.com/cli/internal/gql"
@@ -17,8 +18,7 @@ var OrganizationListCmd = &cobra.Command{
 	Short: "List all your organizations (login required)",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := list(auth.NumerousTenantAuthenticator, gql.GetClient())
-
-		return err
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"numerous.com/cli/cmd/deploy"
 	"numerous.com/cli/cmd/dev"
 	"numerous.com/cli/cmd/download"
+	"numerous.com/cli/cmd/errorhandling"
 	cmdinit "numerous.com/cli/cmd/init"
 	"numerous.com/cli/cmd/legacy"
 	"numerous.com/cli/cmd/login"
@@ -45,8 +46,8 @@ var (
 			"             °°°°°   \n" +
 			"                °°     \n" +
 			"",
-		SilenceUsage:  true,
 		SilenceErrors: true,
+		SilenceUsage:  true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			output.NotifyFeedbackMaybe()
 
@@ -99,6 +100,11 @@ func commandRequiresAuthentication(invokedCommandName string) bool {
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
+		if !errors.Is(err, errorhandling.ErrAlreadyPrinted) {
+			output.PrintError("Error: %s", "", err.Error())
+			println()
+			rootCmd.Usage() // nolint: errcheck
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/token/create/cmd.go
+++ b/cmd/token/create/cmd.go
@@ -2,6 +2,7 @@ package create
 
 import (
 	"github.com/spf13/cobra"
+	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/internal/gql"
 	"numerous.com/cli/internal/token"
 )
@@ -15,7 +16,8 @@ var Cmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a personal access token.",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return Create(cmd.Context(), token.NewService(gql.NewClient()), CreateInput{Name: name, Description: desc})
+		err := Create(cmd.Context(), token.NewService(gql.NewClient()), CreateInput{Name: name, Description: desc})
+		return errorhandling.ErrorAlreadyPrinted(err)
 	},
 }
 


### PR DESCRIPTION
Improve consistency in how errors are presented to users.

Do not re-print errors in the command wrapper that have already been printed internally, but keep the errors to signal that the exit code should be `1`.

Only show usage for command argument errors, not errors happening internally in the command functions.