### PR TITLE
feat: reduce package size with platform specific distributions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,8 @@ jobs:
         uses: dawidd6/action-download-artifact@v3
         with:
           run_id: ${{ github.event.workflow_run.id }}
-          name: package
-          path: dist
+          name: dist
+          path: ./dist
       - run: pip install python-semantic-release==9.6.0 twine==5.0.0
       - run: |
           semantic-release version --commit --tag --push

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,11 +64,17 @@ jobs:
           name: dist-${{ matrix.platform }}
           path: ./dist/*
 
-  collect-dists:
-    name: Collect dists
-    runs-on: ubuntu-latest
-    needs: build
+  test-cli-windows:
+    name: Test CLI on windows
+    runs-on: windows-latest
+    needs:
+      - build
     steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
       - uses: actions/download-artifact@v4
         with:
           name: dist-darwin_amd64
@@ -96,27 +102,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: dist-any
-          path: ./dist
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: ./dist/*
-
-  test-cli-windows:
-    name: Test CLI on windows
-    runs-on: windows-latest
-    needs:
-      - collect-dists
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-          cache: "pip"
-      - uses: actions/download-artifact@v4
-        id: download
-        with:
-          name: dist
           path: ./dist
       - run: pip install pypiserver
       - run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,10 @@ jobs:
   build:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    name: Build distributions
+    name: Build
+    strategy:
+      matrix:
+        platform: ["darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64", "windows_amd64", "windows_arm64", "any"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,7 +58,45 @@ jobs:
           cache: false
       - run: python3 -m pip install python-semantic-release==9.6.0 build>=1.2.1
       - run: semantic-release version --no-commit --no-tag --no-push --no-changelog # update version locally to build new version
-      - run: make packages
+      - run: make package-${{ matrix.platform }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.platform }}
+          path: ./dist/*
+
+  collect-dists:
+    name: Collect dists
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-darwin_amd64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-darwin_arm64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-linux_amd64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-linux_arm64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-windows_amd64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-windows_arm64
+          path: ./dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-any
+          path: ./dist
       - uses: actions/upload-artifact@v4
         with:
           name: dist
@@ -65,7 +106,7 @@ jobs:
     name: Test CLI on windows
     runs-on: windows-latest
     needs:
-      - build
+      - collect-dists
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,7 +40,7 @@ jobs:
   build:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    name: Build package
+    name: Build distributions
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,10 +55,10 @@ jobs:
           cache: false
       - run: python3 -m pip install python-semantic-release==9.6.0 build>=1.2.1
       - run: semantic-release version --no-commit --no-tag --no-push --no-changelog # update version locally to build new version
-      - run: make package
+      - run: make packages
       - uses: actions/upload-artifact@v4
         with:
-          name: package
+          name: dist
           path: ./dist/*
 
   test-cli-windows:
@@ -75,13 +75,15 @@ jobs:
       - uses: actions/download-artifact@v4
         id: download
         with:
-          name: package
+          name: dist
           path: ./dist
-      - run: cmd /r dir /b /a-d dist > files.txt
       - run: |
-          $files = Get-Content files.txt
+          $files=Get-ChildItem dist
           foreach ($file in $files) {
-            pip install dist/$file
+            if ($file.name -like "*-win_amd64.whl") {
+              pip install $file.fullname
+              break
+            }
           }
       - run: numerous --help
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -77,14 +77,10 @@ jobs:
         with:
           name: dist
           path: ./dist
+      - run: pip install pypiserver
       - run: |
-          $files=Get-ChildItem dist
-          foreach ($file in $files) {
-            if ($file.name -like "*-win_amd64.whl") {
-              pip install $file.fullname
-              break
-            }
-          }
+          python -m pypiserver run -p 8000 ./dist &
+          pip install --index-url=http://localhost:8000/simple numerous
       - run: numerous --help
 
   lint-cli:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -64,17 +64,11 @@ jobs:
           name: dist-${{ matrix.platform }}
           path: ./dist/*
 
-  test-cli-windows:
-    name: Test CLI on windows
-    runs-on: windows-latest
-    needs:
-      - build
+  collect-dists:
+    name: Collect dists
+    runs-on: ubuntu-latest
+    needs: build
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-          cache: "pip"
       - uses: actions/download-artifact@v4
         with:
           name: dist-darwin_amd64
@@ -102,6 +96,26 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: dist-any
+          path: ./dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ./dist/*
+
+  test-cli-windows:
+    name: Test CLI on windows
+    runs-on: windows-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-windows_amd64
           path: ./dist
       - run: pip install pypiserver
       - run: |

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-cli/build/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -181,3 +180,6 @@ internal/version/version.txt
 
 # Python package dist
 numerous-*
+
+# SDK cli binaries
+python/src/numerous/cli/bin

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 global-include py.typed
-include python/src/numerous/cli/build/*
+include python/src/numerous/cli/bin/*

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ SDK_CLI_BINARY_DIR=python/src/numerous/cli/bin
 SDK_CHECK_VENV=@if [ -z "${VIRTUAL_ENV}" ]; then echo "-- Error: An activated virtual environment is required"; exit 1; fi
 
 # Packaging
-PACKAGE_TARGETS := $(foreach TARGET,$(TARGETS),package-$(TARGET))
+PLATFORM_PACKAGE_TARGETS := $(foreach TARGET,$(TARGETS),package-$(TARGET))
+PACKAGE_TARGETS = $(PLATFORM_PACKAGE_TARGETS) package-any
 
 # Version
 create_version_txt_cmd=grep '^version = ".\+"' pyproject.toml | tr -d '\n' | sed 's/^version = "\(.\+\)"/\1/' > $(VERSION_TXT)
@@ -51,7 +52,7 @@ clean:
 	rm -f .lint-mypy.txt
 	rm -f $(VERSION_TXT)
 
-packages: ${PACKAGE_TARGETS}
+packages: $(PACKAGE_TARGETS)
 
 test: sdk-test cli-test
 
@@ -86,7 +87,7 @@ $(SDK_CLI_BINARY_DIR)/%: $(SDK_CLI_BINARY_DIR) $(CLI_BUILD_DIR)/%
 	echo "-- Copying built binary $@"
 	cp $(get_cli_target_from_sdk_binary) $@
 
-$(PACKAGE_TARGETS): package-% : $(CLI_BUILD_DIR)/%
+$(PLATFORM_PACKAGE_TARGETS): package-% : $(CLI_BUILD_DIR)/%
 	echo "-- Building package $*"
 	scripts/build_dists.sh $(notdir $*)
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ create_version_txt_cmd=grep '^version = ".\+"' pyproject.toml | tr -d '\n' | sed
 # RULES
 .DEFAULT_GOAL := help
 
-.PHONY: clean test lint dep package sdk-binaries sdk-test sdk-lint sdk-dep cli-test cli-lint cli-dep cli-all cli-build cli-local version $(PACKAGE_TARGETS)
+.PHONY: clean packages test lint dep sdk-test sdk-lint sdk-dep cli-test cli-lint cli-dep cli-all cli-build cli-local version $(PACKAGE_TARGETS)
 
 clean:
 	rm -rf $(CLI_BUILD_DIR)
@@ -135,11 +135,12 @@ version:
 
 help:
 	@echo "Make targets (help is default):"
+	@echo "    clean        Clean all build artifacts"
 	@echo "    test         Run all tests"
 	@echo "    lint         Run all linters"
 	@echo "    dep          Install all dependencies"
-	@echo "    package      Package the SDK python package including CLI builds"
-	@echo "    sdk-binaries Build CLI binaries in SDK package"
+	@echo "    packages     Create all SDK distributions with CLI binaries"
+	@echo "    pkg-PLAT     Create SDK distribution for platform PLAT, e.g. linux_amd64"
 	@echo "    sdk-test     Run SDK tests"
 	@echo "    sdk-lint     Run SDK linters"
 	@echo "    sdk-dep      Install SDK dependencies"
@@ -149,4 +150,6 @@ help:
 	@echo "    cli-all      Build CLI for all systems"
 	@echo "    cli-build    Build CLI for current system"
 	@echo "    cli-local    Build local CLI for current system"
+	@echo "    gqlgen       Generate graphql code"
+	@echo "    version      Generate version file for embedding in CLI"
 	@echo "    help         Display this message"

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,7 @@ LDFLAGS = -s -w \
 
 
 # Python SDK related variables
-SDK_CLI_BINARY_DIR=python/src/numerous/cli/build
-SDK_CLI_BINARY_TARGETS := $(foreach SYS,$(TARGET_SYSTEMS),$(foreach ARCH,$(TARGET_ARCHS),$(SDK_CLI_BINARY_DIR)/$(SYS)_$(ARCH)))
+SDK_CLI_BINARY_DIR=python/src/numerous/cli/bin
 SDK_CHECK_VENV=@if [ -z "${VIRTUAL_ENV}" ]; then echo "-- Error: An activated virtual environment is required"; exit 1; fi
 
 # Version
@@ -48,9 +47,9 @@ clean:
 	rm -f .lint-mypy.txt
 	rm -f $(VERSION_TXT)
 
-package: sdk-binaries
-	@echo "-- Building SDK package"
-	python -m build
+packages: ${CLI_BUILD_TARGETS}
+	@echo "-- Building SDK packages"
+	bash scripts/build_dists.sh
 
 test: sdk-test cli-test
 
@@ -74,8 +73,6 @@ sdk-dep:
 	@echo "-- Installing SDK dependencies"
 	$(SDK_CHECK_VENV)
 	pip install -e .[dev] -q
-
-sdk-binaries: $(SDK_CLI_BINARY_TARGETS)
 
 # Directory for CLI binaries, in SDK
 $(SDK_CLI_BINARY_DIR):

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,7 @@ clean:
 	rm -f .lint-mypy.txt
 	rm -f $(VERSION_TXT)
 
-packages: ${CLI_BUILD_TARGETS}
-	@echo "-- Building SDK packages"
-	bash scripts/build_dists.sh
+packages: ${PACKAGE_TARGETS}
 
 test: sdk-test cli-test
 
@@ -85,12 +83,16 @@ $(SDK_CLI_BINARY_DIR):
 
 # CLI executables in SDK
 $(SDK_CLI_BINARY_DIR)/%: $(SDK_CLI_BINARY_DIR) $(CLI_BUILD_DIR)/%
-	echo "Copying built binary $@"
+	echo "-- Copying built binary $@"
 	cp $(get_cli_target_from_sdk_binary) $@
 
 $(PACKAGE_TARGETS): package-% : $(CLI_BUILD_DIR)/%
-	echo "Building package $*"
+	echo "-- Building package $*"
 	scripts/build_dists.sh $(notdir $*)
+
+package-any: $(CLI_BUILD_TARGETS)
+	echo "-- Building 'any' package"
+	scripts/build_dists.sh any
 
 # CLI for specific OS/architecture
 cli-all: $(CLI_BUILD_TARGETS)

--- a/python/src/numerous/cli/run.py
+++ b/python/src/numerous/cli/run.py
@@ -31,19 +31,30 @@ def get_executable_arch_name() -> str:
     if arch == "arm64":
         return "arm64"
     print(  # noqa: T201
-        f"Sorry but architecutre {arch} is not currently supported :(",
+        f"Sorry but architecture {arch} is not currently supported :(",
     )
     sys.exit(1)
 
 
-def get_executable_name() -> str:
-    return f"build/{get_executable_os_name()}_{get_executable_arch_name()}"
+def get_generic_executable_name() -> str:
+    return f"{get_executable_os_name()}_{get_executable_arch_name()}"
 
 
 def main() -> int:
     check_for_updates()
-    exe_name = get_executable_name()
-    exe_path = Path(__file__).parent / exe_name
+    bin_dir = Path(__file__).parent / "bin"
+    if (bin_dir / "cli").exists():
+        exe_path = bin_dir / "cli"
+    else:
+        exe_name = get_generic_executable_name()
+        exe_path = bin_dir / exe_name
+
+    if not exe_path.exists():
+        print(  # noqa: T201
+            "Numerous CLI executable compatible with your system was not found. :("
+        )
+        sys.exit(1)
+
     try:
         process = subprocess.Popen(args=[str(exe_path)] + sys.argv[1:])
         exit_code = process.wait()

--- a/scripts/build_dists.sh
+++ b/scripts/build_dists.sh
@@ -8,8 +8,8 @@ function python_platforms() {
         'linux_arm64') echo "manylinux_2_17_aarch64";;
         'windows_amd64') echo "win_amd64";;
         'windows_arm64') echo "win_arm64";;
-        'darwin_amd64') echo "macosx_10_0_x86_64 macosx_11_0_x86_64 macosx_12_0_x86_64 macosx_13_0_x86_64 macosx_14_0_x86_64";;
-        'darwin_arm64') echo "macosx_10_0_arm64 macosx_11_0_arm64 macosx_12_0_arm64 macosx_13_0_arm64 macosx_14_0_arm64";;
+        'darwin_amd64') echo "macosx_10_0_x86_64 macosx_11_0_x86_64";;
+        'darwin_arm64') echo "macosx_10_0_arm64 macosx_11_0_arm64";;
         *) >&2 echo "Unexpected platform $1"; exit 1;;
     esac
 }

--- a/scripts/build_dists.sh
+++ b/scripts/build_dists.sh
@@ -2,6 +2,18 @@
 
 bin_dir=python/src/numerous/cli/bin
 
+function python_platforms() {
+    case "$1" in
+        'linux_amd64') echo "manylinux_2_17_x86_64";;
+        'linux_arm64') echo "manylinux_2_17_aarch64";;
+        'windows_amd64') echo "win_amd64";;
+        'windows_arm64') echo "win_arm64";;
+        'darwin_amd64') echo "macosx_10_0_x86_64 macosx_11_0_x86_64 macosx_12_0_x86_64 macosx_13_0_x86_64 macosx_14_0_x86_64";;
+        'darwin_arm64') echo "macosx_10_0_arm64 macosx_11_0_arm64 macosx_12_0_arm64 macosx_13_0_arm64 macosx_14_0_arm64";;
+        *) >&2 echo "Unexpected platform $1"; exit 1;;
+    esac
+}
+
 function clean_bins() {
     rm -f $bin_dir/*
 }
@@ -16,29 +28,36 @@ function copy_bins() {
     cp build/darwin_amd64 build/darwin_arm64 build/linux_amd64 build/linux_arm64 build/windows_amd64 build/windows_arm64 $bin_dir
 }
 
-function build_wheels() {
-    mkdir $bin_dir || echo "Already exists"
+function build_platform_dist() {
+    plat_names="$(python_platforms $1)"
+    copy_bin $1
+    for plat_name in $plat_names; do
+        echo "Building wheel for $1 => $plat_name"
+        python -m build --wheel "-C=--build-option=--plat-name=$plat_name"
+    done
+}
 
-    copy_bin "linux_amd64"
-    python -m build --wheel "-C=--build-option=--plat-name=manylinux_2_17_x86_64"
-
-    copy_bin "linux_arm64"
-    python -m build --wheel "-C=--build-option=--plat-name=manylinux_2_17_aarch64"
-
-    copy_bin "windows_amd64"
-    python -m build --wheel "-C=--build-option=--plat-name=win_amd64"
-
-    copy_bin "windows_arm64"
-    python -m build --wheel "-C=--build-option=--plat-name=win_arm64"
-
-    copy_bin "darwin_amd64"
-    python -m build --wheel "-C=--build-option=--plat-name=macosx_10_9_x86_64"
-
-    copy_bin "darwin_arm64"
-    python -m build --wheel "-C=--build-option=--plat-name=macosx_10_9_arm64"
-
+function build_multi_dist {
     copy_bins
     python -m build
 }
 
-build_wheels
+function build_dists() {
+    build_platform_dist "linux_amd64"
+    build_platform_dist "linux_arm64"
+    build_platform_dist "windows_amd64"
+    build_platform_dist "windows_arm64"
+    build_platform_dist "darwin_amd64"
+    build_platform_dist "darwin_arm64"
+    build_multi_dist
+}
+
+mkdir $bin_dir 2>/dev/null
+if [[ -z "$1" ]]; then
+    build_dists
+elif [[ "$1" = "any" ]]; then
+    build_multi_dist
+else
+    build_platform_dist $1
+fi
+

--- a/scripts/build_dists.sh
+++ b/scripts/build_dists.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+bin_dir=python/src/numerous/cli/bin
+
+function clean_bins() {
+    rm -f $bin_dir/*
+}
+
+function copy_bin() {
+    clean_bins
+    cp build/$1 $bin_dir/cli
+}
+
+function copy_bins() {
+    clean_bins
+    cp build/darwin_amd64 build/darwin_arm64 build/linux_amd64 build/linux_arm64 build/windows_amd64 build/windows_arm64 $bin_dir
+}
+
+function build_wheels() {
+    mkdir $bin_dir || echo "Already exists"
+
+    copy_bin "linux_amd64"
+    python -m build --wheel "-C=--build-option=--plat-name=manylinux_2_17_x86_64"
+
+    copy_bin "linux_arm64"
+    python -m build --wheel "-C=--build-option=--plat-name=manylinux_2_17_aarch64"
+
+    copy_bin "windows_amd64"
+    python -m build --wheel "-C=--build-option=--plat-name=win_amd64"
+
+    copy_bin "windows_arm64"
+    python -m build --wheel "-C=--build-option=--plat-name=win_arm64"
+
+    copy_bin "darwin_amd64"
+    python -m build --wheel "-C=--build-option=--plat-name=macosx_10_9_x86_64"
+
+    copy_bin "darwin_arm64"
+    python -m build --wheel "-C=--build-option=--plat-name=macosx_10_9_arm64"
+
+    copy_bins
+    python -m build
+}
+
+build_wheels


### PR DESCRIPTION
Reduces package size by a factor of 6: ~66MB to ~11MB.

Changes how the CLI binaries are added to the python package, and how
the python executable launches the binary.

1. The binaries are now located in `numerous/cli/bin`.
2. The python script tries to launch `numerous/cli/bin/cli` if it
   exists. It exists if the package is installed from a platform
   specific wheel.
3. Otherwise the python script will attempt to match the the current OS
   with a binary, similar to the approach until now. This is meant for
   non-platform specific wheels.

The build process is changed. Wheels and source distribution are created
by `scripts/build_dists.sh`, which creates a bdist for each relevant
platform that we build CLI binaries for. The CLI binary directory
`numerous/cli/bin` is cleared, and the relevant CLI binary is copied
into `numerous/cli/bin/cli`, and the corresponding wheel is created.

For the platform non-specific wheel and the source distribution all
binaries are added, as before.