### PR TITLE
feat(api): streamline deployment workload status output

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -224,6 +224,7 @@ func deployApp(ctx context.Context, appVersionOutput app.CreateAppVersionOutput,
 		output.PrintErrorDetails("Error deploying app", err)
 	}
 
+	appDeploymentStatusEventUpdater := statusUpdater{verbose: input.Verbose, task: task}
 	eventsInput := app.DeployEventsInput{
 		DeploymentVersionID: deployAppOutput.DeploymentVersionID,
 		Handler: func(de app.DeployEvent) error {
@@ -243,13 +244,8 @@ func deployApp(ctx context.Context, appVersionOutput app.CreateAppVersionOutput,
 
 				return &deployBuildError{Message: de.BuildError.Message}
 			case "AppDeploymentStatusEvent":
-				if input.Verbose {
-					task.AddLine("Deploy", "Status is "+de.DeploymentStatus.Status)
-				}
-				switch de.DeploymentStatus.Status {
-				case "PENDING", "RUNNING":
-				default:
-					return fmt.Errorf("got status %s while deploying", de.DeploymentStatus.Status)
+				if err := appDeploymentStatusEventUpdater.update(de.DeploymentStatus.Status); err != nil {
+					return err
 				}
 			}
 
@@ -270,6 +266,39 @@ func deployApp(ctx context.Context, appVersionOutput app.CreateAppVersionOutput,
 		return err
 	}
 	task.Done()
+
+	return nil
+}
+
+type statusUpdater struct {
+	verbose               bool
+	lastStatus            *string
+	sameStatusUpdateCount int
+	task                  *output.Task
+}
+
+func (s *statusUpdater) update(status string) error {
+	if s.verbose {
+		if s.lastStatus != nil && *s.lastStatus != status {
+			s.task.UpdateLine("Deploy", "Workload is "+strings.ToLower(*s.lastStatus)+strings.Repeat(".", s.sameStatusUpdateCount)+"\n")
+		}
+
+		isDifferent := s.lastStatus == nil || *s.lastStatus != status
+		if isDifferent {
+			s.sameStatusUpdateCount = 0
+		} else {
+			s.sameStatusUpdateCount++
+		}
+
+		s.lastStatus = &status
+		s.task.UpdateLine("Deploy", "Workload is "+strings.ToLower(status)+strings.Repeat(".", s.sameStatusUpdateCount))
+	}
+
+	switch status {
+	case "PENDING", "RUNNING":
+	default:
+		return fmt.Errorf("got status %s while deploying", status)
+	}
 
 	return nil
 }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -273,14 +273,14 @@ func deployApp(ctx context.Context, appVersionOutput app.CreateAppVersionOutput,
 type statusUpdater struct {
 	verbose               bool
 	lastStatus            *string
-	sameStatusUpdateCount int
+	sameStatusUpdateCount uint
 	task                  *output.Task
 }
 
 func (s *statusUpdater) update(status string) error {
 	if s.verbose {
 		if s.lastStatus != nil && *s.lastStatus != status {
-			s.task.UpdateLine("Deploy", "Workload is "+strings.ToLower(*s.lastStatus)+strings.Repeat(".", s.sameStatusUpdateCount)+"\n")
+			s.task.EndUpdateLine()
 		}
 
 		isDifferent := s.lastStatus == nil || *s.lastStatus != status
@@ -291,7 +291,7 @@ func (s *statusUpdater) update(status string) error {
 		}
 
 		s.lastStatus = &status
-		s.task.UpdateLine("Deploy", "Workload is "+strings.ToLower(status)+strings.Repeat(".", s.sameStatusUpdateCount))
+		s.task.UpdateLine("Deploy", "Workload is "+strings.ToLower(status)+strings.Repeat(".", int(s.sameStatusUpdateCount)))
 	}
 
 	switch status {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -2,14 +2,19 @@ package deploy
 
 import (
 	"context"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
+	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/appident"
 	"numerous.com/cli/internal/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeploy(t *testing.T) {
@@ -20,20 +25,28 @@ func TestDeploy(t *testing.T) {
 	const uploadURL = "https://upload/url"
 	const deployVersionID = "deploy-version-id"
 
-	mockVersionDeploy := func(apps *mockAppService) {
+	mockVersionDeployWithDeployEventsRun := func(apps *mockAppService, deployEventsRun func(mock.Arguments)) {
 		apps.On("CreateVersion", mock.Anything, mock.Anything).Return(app.CreateAppVersionOutput{AppVersionID: appVersionID}, nil)
 		apps.On("AppVersionUploadURL", mock.Anything, mock.Anything).Return(app.AppVersionUploadURLOutput{UploadURL: uploadURL}, nil)
 		apps.On("UploadAppSource", mock.Anything, mock.Anything).Return(nil)
 		apps.On("DeployApp", mock.Anything, mock.Anything).Return(app.DeployAppOutput{DeploymentVersionID: deployVersionID}, nil)
-		apps.On("DeployEvents", mock.Anything, mock.Anything).Return(nil)
+		apps.On("DeployEvents", mock.Anything, mock.Anything).Run(deployEventsRun).Return(nil)
+	}
+
+	mockVersionDeploy := func(apps *mockAppService) {
+		mockVersionDeployWithDeployEventsRun(apps, nil)
+	}
+
+	mockAppExistsWithDeployEventsRun := func(deployEventsRun func(mock.Arguments)) *mockAppService {
+		apps := &mockAppService{}
+		apps.On("ReadApp", mock.Anything, mock.Anything).Return(app.ReadAppOutput{AppID: appID}, nil)
+		mockVersionDeployWithDeployEventsRun(apps, deployEventsRun)
+
+		return apps
 	}
 
 	mockAppExists := func() *mockAppService {
-		apps := &mockAppService{}
-		apps.On("ReadApp", mock.Anything, mock.Anything).Return(app.ReadAppOutput{AppID: appID}, nil)
-		mockVersionDeploy(apps)
-
-		return apps
+		return mockAppExistsWithDeployEventsRun(nil)
 	}
 
 	mockAppNotExists := func() *mockAppService {
@@ -196,4 +209,73 @@ func TestDeploy(t *testing.T) {
 			apps.AssertCalled(t, "CreateVersion", mock.Anything, expectedInput)
 		}
 	})
+
+	t.Run("prints expected verbose messages", func(t *testing.T) {
+		appDir := t.TempDir()
+		test.CopyDir(t, "../../testdata/streamlit_app", appDir)
+		expectedVersion := "v1.2.3"
+		expectedMessage := "expected message"
+		apps := mockAppExistsWithDeployEventsRun(func(args mock.Arguments) {
+			input := args.Get(1).(app.DeployEventsInput)
+			input.Handler(app.DeployEvent{Typename: "AppBuildMessageEvent", BuildMessage: app.AppBuildMessageEvent{Message: "Build message 1"}})    // nolint:errcheck
+			input.Handler(app.DeployEvent{Typename: "AppBuildMessageEvent", BuildMessage: app.AppBuildMessageEvent{Message: "Build message 2"}})    // nolint:errcheck
+			input.Handler(app.DeployEvent{Typename: "AppDeploymentStatusEvent", DeploymentStatus: app.AppDeploymentStatusEvent{Status: "PENDING"}}) // nolint:errcheck
+			input.Handler(app.DeployEvent{Typename: "AppDeploymentStatusEvent", DeploymentStatus: app.AppDeploymentStatusEvent{Status: "PENDING"}}) // nolint:errcheck
+			input.Handler(app.DeployEvent{Typename: "AppDeploymentStatusEvent", DeploymentStatus: app.AppDeploymentStatusEvent{Status: "PENDING"}}) // nolint:errcheck
+			input.Handler(app.DeployEvent{Typename: "AppDeploymentStatusEvent", DeploymentStatus: app.AppDeploymentStatusEvent{Status: "RUNNING"}}) // nolint:errcheck
+		})
+		stdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+		defer func() {
+			os.Stdout = stdout
+		}()
+
+		input := DeployInput{AppDir: appDir, OrgSlug: slug, AppSlug: appSlug, Version: expectedVersion, Message: expectedMessage, Verbose: true}
+		err = Deploy(context.TODO(), apps, input)
+
+		require.NoError(t, w.Close())
+		assert.NoError(t, err)
+		expected := []string{
+			"<nonascii> Loading app configuration............................",
+			"\r<nonascii> Loading app configuration............................OK\n",
+			"<nonascii> Registering new version for organization-slug/app-...",
+			"\r<nonascii> Registering new version for organization-slug/app-...OK\n",
+			"<nonascii> Creating app archive.................................",
+			"\r<nonascii> Creating app archive.................................OK\n",
+			"<nonascii> Uploading app archive................................",
+			"\r<nonascii> Uploading app archive................................OK\n",
+			"<nonascii> Deploying app........................................\n",
+			"Build Build message 1\n",
+			"Build Build message 2\n",
+			"\rDeploy Workload is pending",
+			"\rDeploy Workload is pending.",
+			"\rDeploy Workload is pending..",
+			"\rDeploy Workload is pending..\n",
+			"\rDeploy Workload is running\n",
+			"<nonascii> Deploying app........................................OK\n",
+			"<nonascii> Access your app at: https://www.numerous.com/app/organization/organization-slug/private/app-slug\n",
+		}
+		output, _ := io.ReadAll(r)
+		actual := stripNonASCII(string(output))
+		assert.Equal(t, strings.Join(expected, ""), actual)
+	})
+}
+
+func stripNonASCII(s string) string {
+	var stripped string
+	for _, r := range s {
+		if r < 128 {
+			stripped += string(r)
+		} else {
+			stripped += "<nonascii>"
+		}
+	}
+
+	for _, code := range []string{output.AnsiRed, output.AnsiReset, output.AnsiGreen, output.AnsiFaint} {
+		stripped = strings.ReplaceAll(stripped, code, "")
+	}
+
+	return stripped
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -238,44 +238,43 @@ func TestDeploy(t *testing.T) {
 		require.NoError(t, w.Close())
 		assert.NoError(t, err)
 		expected := []string{
-			"<nonascii> Loading app configuration............................",
-			"\r<nonascii> Loading app configuration............................OK\n",
-			"<nonascii> Registering new version for organization-slug/app-...",
-			"\r<nonascii> Registering new version for organization-slug/app-...OK\n",
-			"<nonascii> Creating app archive.................................",
-			"\r<nonascii> Creating app archive.................................OK\n",
-			"<nonascii> Uploading app archive................................",
-			"\r<nonascii> Uploading app archive................................OK\n",
-			"<nonascii> Deploying app........................................\n",
+			"<non-ascii> Loading app configuration............................",
+			"\r<non-ascii> Loading app configuration............................OK\n",
+			"<non-ascii> Registering new version for organization-slug/app-...",
+			"\r<non-ascii> Registering new version for organization-slug/app-...OK\n",
+			"<non-ascii> Creating app archive.................................",
+			"\r<non-ascii> Creating app archive.................................OK\n",
+			"<non-ascii> Uploading app archive................................",
+			"\r<non-ascii> Uploading app archive................................OK\n",
+			"<non-ascii> Deploying app........................................\n",
 			"Build Build message 1\n",
 			"Build Build message 2\n",
 			"\rDeploy Workload is pending",
 			"\rDeploy Workload is pending.",
-			"\rDeploy Workload is pending..",
 			"\rDeploy Workload is pending..\n",
 			"\rDeploy Workload is running\n",
-			"<nonascii> Deploying app........................................OK\n",
-			"<nonascii> Access your app at: https://www.numerous.com/app/organization/organization-slug/private/app-slug\n",
+			"<non-ascii> Deploying app........................................OK\n",
+			"<non-ascii> Access your app at: https://www.numerous.com/app/organization/organization-slug/private/app-slug\n",
 		}
 		output, _ := io.ReadAll(r)
-		actual := stripNonASCII(string(output))
+		actual := cleanNonASCIIAndANSI(string(output))
 		assert.Equal(t, strings.Join(expected, ""), actual)
 	})
 }
 
-func stripNonASCII(s string) string {
-	var stripped string
+func cleanNonASCIIAndANSI(s string) string {
+	var cleaned string
 	for _, r := range s {
 		if r < 128 {
-			stripped += string(r)
+			cleaned += string(r)
 		} else {
-			stripped += "<nonascii>"
+			cleaned += "<non-ascii>"
 		}
 	}
 
 	for _, code := range []string{output.AnsiRed, output.AnsiReset, output.AnsiGreen, output.AnsiFaint} {
-		stripped = strings.ReplaceAll(stripped, code, "")
+		cleaned = strings.ReplaceAll(cleaned, code, "")
 	}
 
-	return stripped
+	return cleaned
 }

--- a/cmd/output/ok.go
+++ b/cmd/output/ok.go
@@ -5,5 +5,5 @@ import "fmt"
 // Prints message as a line prefixed with a green checkmark. Additional
 // arguments are used for formatting.
 func PrintlnOK(message string, args ...any) {
-	fmt.Printf(AnsiGreen+checkmark+AnsiReset+" "+message+"\n", args...)
+	fmt.Printf(AnsiGreen+checkmarkIcon+AnsiReset+" "+message+"\n", args...)
 }

--- a/cmd/output/symbols.go
+++ b/cmd/output/symbols.go
@@ -3,11 +3,11 @@ package output
 import "runtime"
 
 const (
-	hourglass    = "\u29D6"
-	errorcross   = AnsiRed + "\u2715" + AnsiReset
-	checkmark    = AnsiGreen + "\u2713" + AnsiReset
-	raiseHand    = "\U0000270B"
-	shootingStar = "\U0001F320"
+	hourglassIcon = "\u29D6"
+	errorcross    = AnsiRed + "\u2715" + AnsiReset
+	checkmarkIcon = AnsiGreen + "\u2713" + AnsiReset
+	raiseHand     = "\U0000270B"
+	shootingStar  = "\U0001F320"
 )
 
 func symbol(value string) string {

--- a/cmd/output/task.go
+++ b/cmd/output/task.go
@@ -15,10 +15,11 @@ const (
 type lineWidthFunc func() int
 
 type Task struct {
-	msg       string
-	lineAdded bool
-	lineWidth lineWidthFunc
-	w         io.Writer
+	msg          string
+	lineAdded    bool
+	lineUpdating bool
+	lineWidth    lineWidthFunc
+	w            io.Writer
 }
 
 func (t *Task) line(icon string) string {
@@ -52,32 +53,45 @@ func (t *Task) trimMessage() (int, string) {
 }
 
 func (t *Task) start() {
-	ln := t.line(hourglass)
+	ln := t.line(hourglassIcon)
 	fmt.Fprint(t.w, ln)
 }
 
 func (t *Task) AddLine(prefix string, line string) {
-	if !t.lineAdded {
+	if !t.lineAdded || t.lineUpdating {
 		fmt.Fprintln(t.w)
 	}
 	fmt.Fprintln(t.w, AnsiReset+AnsiFaint+prefix+AnsiReset, line)
+	t.lineUpdating = false
+	t.lineAdded = true
+}
+
+func (t *Task) UpdateLine(prefix string, line string) {
+	if !t.lineAdded {
+		fmt.Fprintln(t.w)
+	}
+	fmt.Fprint(t.w, "\r"+AnsiReset+AnsiFaint+prefix+AnsiReset+" "+line)
+	t.lineUpdating = true
 	t.lineAdded = true
 }
 
 func (t *Task) Done() {
-	ln := t.line(checkmark)
-	if !t.lineAdded {
-		fmt.Fprint(t.w, "\r")
-	}
-	fmt.Fprintln(t.w, ln+AnsiGreen+"OK"+AnsiReset)
+	t.terminate(checkmarkIcon, AnsiGreen+"OK"+AnsiReset)
 }
 
 func (t *Task) Error() {
-	ln := t.line(errorcross)
+	t.terminate(errorcross, AnsiRed+"Error"+AnsiReset)
+}
+
+func (t *Task) terminate(icon, status string) {
+	ln := t.line(icon)
+	if t.lineUpdating {
+		fmt.Fprintln(t.w)
+	}
 	if !t.lineAdded {
 		fmt.Fprint(t.w, "\r")
 	}
-	fmt.Fprintln(t.w, ln+AnsiRed+"Error"+AnsiReset)
+	fmt.Fprintln(t.w, ln+status)
 }
 
 type terminal interface {

--- a/cmd/output/task.go
+++ b/cmd/output/task.go
@@ -75,6 +75,13 @@ func (t *Task) UpdateLine(prefix string, line string) {
 	t.lineAdded = true
 }
 
+func (t *Task) EndUpdateLine() {
+	if t.lineUpdating {
+		fmt.Fprintln(t.w)
+		t.lineUpdating = false
+	}
+}
+
 func (t *Task) Done() {
 	t.terminate(checkmarkIcon, AnsiGreen+"OK"+AnsiReset)
 }

--- a/cmd/output/task_test.go
+++ b/cmd/output/task_test.go
@@ -91,7 +91,7 @@ func TestTask(t *testing.T) {
 					StartTaskWithTerminal(tc.msg, term)
 
 					actual := buf.String()
-					expected := hourglass + tc.expected
+					expected := hourglassIcon + tc.expected
 					assert.Equal(t, expected, actual)
 				})
 			}
@@ -111,7 +111,7 @@ func TestTask(t *testing.T) {
 					task.Done()
 
 					actual := buf.String()
-					expected := "\r" + checkmark + tc.expected + greenOK + "\n"
+					expected := "\r" + checkmarkIcon + tc.expected + greenOK + "\n"
 					assert.Equal(t, expected, actual)
 				})
 			}
@@ -151,13 +151,116 @@ func TestTask(t *testing.T) {
 		actual := buf.String()
 
 		expected := strings.Join([]string{
-			hourglass + " task message" + AnsiFaint + "......" + AnsiReset,
+			hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset,
 			AnsiReset + AnsiFaint + "prefix" + AnsiReset + " line 1",
 			AnsiReset + AnsiFaint + "prefix" + AnsiReset + " line 2",
 			AnsiReset + AnsiFaint + "prefix" + AnsiReset + " line 3",
-			checkmark + " task message" + AnsiFaint + "......" + AnsiReset + AnsiGreen + "OK" + AnsiReset + "\n",
+			checkmarkIcon + " task message" + AnsiFaint + "......" + AnsiReset + AnsiGreen + "OK" + AnsiReset + "\n",
 		}, "\n")
 		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("UpdateLine", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		term := &stubTerminal{buf: buf, width: 25}
+
+		t.Run("linebreak if no line is added", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line")
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("updates lines with carriage returns", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line version 1")
+			task.UpdateLine("prefix", "updating line version 2")
+			task.UpdateLine("prefix", "updating line version 3")
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line version 1",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line version 2",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line version 3",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("linebreak after preceding added line", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.AddLine("prefix", "preceding added line")
+			task.UpdateLine("prefix", "updating line")
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				AnsiReset + AnsiFaint + "prefix" + AnsiReset + " preceding added line" + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("linebreak before following added line", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line")
+			task.AddLine("prefix", "following added line")
+			task.Done()
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line" + "\n",
+				AnsiReset + AnsiFaint + "prefix" + AnsiReset + " following added line" + "\n",
+				checkmarkIcon + " task message" + AnsiFaint + "......" + AnsiReset + AnsiGreen + "OK" + AnsiReset + "\n",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("linebreak before task done", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line")
+			task.Done()
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line" + "\n",
+				checkmarkIcon + " task message" + AnsiFaint + "......" + AnsiReset + AnsiGreen + "OK" + AnsiReset + "\n",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("linebreak before task error", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line")
+			task.Error()
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line" + "\n",
+				errorcross + " task message" + AnsiFaint + "......" + AnsiReset + AnsiRed + "Error" + AnsiReset + "\n",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
 	})
 
 	t.Run("StartTask", func(t *testing.T) {
@@ -174,7 +277,7 @@ func TestTask(t *testing.T) {
 			assert.NoError(t, w.Close())
 			actual, err := io.ReadAll(r)
 			assert.NoError(t, err)
-			expected := hourglass + " message" + AnsiFaint + ".............................................." + AnsiReset
+			expected := hourglassIcon + " message" + AnsiFaint + ".............................................." + AnsiReset
 			assert.Equal(t, expected, string(actual))
 		})
 	})

--- a/cmd/output/task_test.go
+++ b/cmd/output/task_test.go
@@ -263,6 +263,58 @@ func TestTask(t *testing.T) {
 		})
 	})
 
+	t.Run("EndUpdateLine", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		term := &stubTerminal{buf: buf, width: 25}
+
+		t.Run("adds a single linebreak after updating line", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line that is ended")
+			task.EndUpdateLine()
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line that is ended\n",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("is idempontent", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.UpdateLine("prefix", "updating line that is ended")
+			task.EndUpdateLine()
+			task.EndUpdateLine()
+			task.EndUpdateLine()
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				"\r" + AnsiReset + AnsiFaint + "prefix" + AnsiReset + " updating line that is ended\n",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+
+		t.Run("does not print extra newline after adding line", func(t *testing.T) {
+			buf.Reset()
+
+			task := StartTaskWithTerminal("task message", term)
+			task.AddLine("prefix", "added line")
+			task.EndUpdateLine()
+			actual := buf.String()
+
+			expected := strings.Join([]string{
+				hourglassIcon + " task message" + AnsiFaint + "......" + AnsiReset + "\n",
+				AnsiReset + AnsiFaint + "prefix" + AnsiReset + " added line\n",
+			}, "")
+			assert.Equal(t, expected, actual)
+		})
+	})
+
 	t.Run("StartTask", func(t *testing.T) {
 		t.Run("writes expected output to stdout", func(t *testing.T) {
 			// replace stdout with a pipe that we can read


### PR DESCRIPTION
Instead of printing repeated messages about the same workload status print
dots for each deployment stage is it goes on.