### PR TITLE
feat(cli):  `deploy` command `--follow` flag for following logs after deploy

### DIFF
--- a/cmd/deploy/cmd.go
+++ b/cmd/deploy/cmd.go
@@ -47,6 +47,7 @@ var (
 	projectDir string = "."
 	message    string
 	version    string
+	follow     bool
 )
 
 func run(cmd *cobra.Command, args []string) error {
@@ -60,6 +61,7 @@ func run(cmd *cobra.Command, args []string) error {
 		Message:    message,
 		Version:    version,
 		Verbose:    verbose,
+		Follow:     follow,
 	}
 	err := Deploy(cmd.Context(), service, input)
 
@@ -71,5 +73,6 @@ func init() {
 	flags.StringVarP(&orgSlug, "organization", "o", "", "The organization slug identifier of the app to deploy to. List available organizations with 'numerous organization list'.")
 	flags.StringVarP(&appSlug, "app", "a", "", "A app slug identifier of the app to deploy to.")
 	flags.BoolVarP(&verbose, "verbose", "v", false, "Display detailed information about the app deployment.")
+	flags.BoolVarP(&follow, "follow", "f", false, "Follow app deployment logs after deployment has succeeded.")
 	flags.StringVarP(&projectDir, "project-dir", "p", "", "The project directory, which is the build context if using a custom Dockerfile.")
 }

--- a/cmd/deploy/mock.go
+++ b/cmd/deploy/mock.go
@@ -5,6 +5,7 @@ import (
 	"io"
 
 	"numerous.com/cli/internal/app"
+	"numerous.com/cli/internal/appident"
 
 	"github.com/stretchr/testify/mock"
 )
@@ -55,4 +56,10 @@ func (m *mockAppService) CreateVersion(ctx context.Context, input app.CreateAppV
 func (m *mockAppService) UploadAppSource(uploadURL string, archive io.Reader) error {
 	args := m.Called(uploadURL, archive)
 	return args.Error(0)
+}
+
+// AppDeployLogs implements AppService.
+func (m *mockAppService) AppDeployLogs(ai appident.AppIdentifier) (chan app.AppDeployLogEntry, error) {
+	args := m.Called(ai)
+	return args.Get(0).(chan app.AppDeployLogEntry), args.Error(1)
 }

--- a/cmd/output/notify.go
+++ b/cmd/output/notify.go
@@ -3,7 +3,6 @@ package output
 import (
 	"fmt"
 	"math/rand"
-	"strings"
 )
 
 var notifyCmdMovedBody = AnsiFaint + "A new set of commands related to apps in organizations have been promoted as \n" +
@@ -11,9 +10,7 @@ var notifyCmdMovedBody = AnsiFaint + "A new set of commands related to apps in o
 	"See https://www.numerous.com/docs/cli#legacy-commands for more information."
 
 func Notify(header, body string, args ...any) {
-	if body != "" && strings.HasSuffix(body, "\n") {
-		body += "\n"
-	}
+	body = addTrailingNewLine(body)
 	fmt.Printf(AnsiCyanBold+header+AnsiReset+"\n"+body, args...)
 }
 

--- a/cmd/output/notify.go
+++ b/cmd/output/notify.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 )
 
 var notifyCmdMovedBody = AnsiFaint + "A new set of commands related to apps in organizations have been promoted as \n" +
@@ -10,7 +11,10 @@ var notifyCmdMovedBody = AnsiFaint + "A new set of commands related to apps in o
 	"See https://www.numerous.com/docs/cli#legacy-commands for more information."
 
 func Notify(header, body string, args ...any) {
-	fmt.Printf(AnsiCyanBold+header+AnsiReset+"\n"+body+"\n", args...)
+	if body != "" && strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	fmt.Printf(AnsiCyanBold+header+AnsiReset+"\n"+body, args...)
 }
 
 func NotifyCmdMoved(cmd string, newCmd string) {


### PR DESCRIPTION
Note that this was based on the branch from #44 by accident, and I'll rebase it on main, when #44 has been merged.

EDIT: it has been rebased now.