### PR TITLE
fix(cli): deploy apps within project directories

### DIFF
--- a/cmd/deploy/cmd.go
+++ b/cmd/deploy/cmd.go
@@ -44,7 +44,7 @@ var (
 	appSlug    string
 	verbose    bool
 	appDir     string = "."
-	projectDir string = "."
+	projectDir string = ""
 	message    string
 	version    string
 	follow     bool

--- a/cmd/legacy/push/build_events.go
+++ b/cmd/legacy/push/build_events.go
@@ -85,7 +85,7 @@ func buildEventSubscription(client subscriptionClient, w io.Writer, buildID stri
 		}
 
 		if sub.BuildEvents.Typename == "BuildEventFailure" {
-			fmt.Fprintf(w, sub.BuildEvents.Failure.Result)
+			fmt.Fprint(w, sub.BuildEvents.Failure.Result)
 			return errors.New(sub.BuildEvents.Failure.Result)
 		}
 

--- a/cmd/login/login.go
+++ b/cmd/login/login.go
@@ -65,7 +65,7 @@ func login(a auth.Authenticator, ctx context.Context) (*auth.User, error) {
 	}
 
 	if err := a.OpenURL(state.VerificationURI); err != nil {
-		fmt.Printf(
+		fmt.Println(
 			"The browser could not be opened automatically, please go to this site to continue\n" +
 				"the log-in: " + state.VerificationURI,
 		)

--- a/internal/app/app_create.go
+++ b/internal/app/app_create.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 type CreateAppInput struct {
@@ -16,7 +18,7 @@ type CreateAppOutput struct {
 }
 
 const appCreateText = `
-mutation AppCreate($orgSlug: String!, $appSlug: String!, $displayName: String!, $description: String!) {
+mutation CLIAppCreate($orgSlug: String!, $appSlug: String!, $displayName: String!, $description: String!) {
 	appCreate(organizationSlug: $orgSlug, appData: {appSlug: $appSlug, displayName: $displayName, description: $description}) {
 		id
 	}
@@ -38,7 +40,7 @@ func (s *Service) Create(ctx context.Context, input CreateAppInput) (CreateAppOu
 		"displayName": input.DisplayName,
 		"description": input.Description,
 	}
-	err := s.client.Exec(ctx, appCreateText, &resp, variables)
+	err := s.client.Exec(ctx, appCreateText, &resp, variables, graphql.OperationName("CLIAppCreate"))
 	if err != nil {
 		return CreateAppOutput{}, convertErrors(err)
 	}

--- a/internal/app/app_delete.go
+++ b/internal/app/app_delete.go
@@ -2,10 +2,12 @@ package app
 
 import (
 	"context"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 const deleteMutation string = `
-	mutation DeleteApp($orgSlug: String!, $appSlug: String!) {
+	mutation CLIAppDelete($orgSlug: String!, $appSlug: String!) {
 		appDelete(input: {organizationSlug: $orgSlug, appSlug: $appSlug}) {
 			__typename
 		}
@@ -27,7 +29,7 @@ func (s *Service) Delete(ctx context.Context, input DeleteAppInput) error {
 	resp := deleteAppResponse{}
 	vars := map[string]any{"orgSlug": input.OrganizationSlug, "appSlug": input.AppSlug}
 
-	err := s.client.Exec(ctx, deleteMutation, &resp, vars)
+	err := s.client.Exec(ctx, deleteMutation, &resp, vars, graphql.OperationName("CLIAppDelete"))
 	if err != nil {
 		return convertErrors(err)
 	}

--- a/internal/app/app_deploy_logs.go
+++ b/internal/app/app_deploy_logs.go
@@ -5,6 +5,7 @@ import (
 
 	"numerous.com/cli/internal/appident"
 
+	"github.com/hasura/go-graphql-client"
 	"github.com/hasura/go-graphql-client/pkg/jsonutil"
 )
 
@@ -40,7 +41,7 @@ func (s *Service) AppDeployLogs(ai appident.AppIdentifier) (chan AppDeployLogEnt
 	vars := make(map[string]any)
 	vars["orgSlug"] = ai.OrganizationSlug
 	vars["appSlug"] = ai.AppSlug
-	_, err := s.subscription.Subscribe(&AppDeployLogsSubscription{}, vars, handler)
+	_, err := s.subscription.Subscribe(&AppDeployLogsSubscription{}, vars, handler, graphql.OperationName("CLIAppDeployLogs"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/app_list.go
+++ b/internal/app/app_list.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"time"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 type ListApp struct {
@@ -62,7 +64,7 @@ var (
 
 func (s *Service) List(ctx context.Context, organizationSlug string) ([]ListApp, error) {
 	var q QueryOrganizationApps
-	if err := s.client.Query(ctx, &q, map[string]interface{}{"organizationSlug": organizationSlug}); err != nil {
+	if err := s.client.Query(ctx, &q, map[string]interface{}{"organizationSlug": organizationSlug}, graphql.OperationName("CLIAppList")); err != nil {
 		return nil, convertErrors(err)
 	}
 

--- a/internal/app/app_read.go
+++ b/internal/app/app_read.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 type ReadAppInput struct {
@@ -14,7 +16,7 @@ type ReadAppOutput struct {
 }
 
 const queryAppText = `
-query App($orgSlug: String!, $appSlug: String!) {
+query CLIAppRead($orgSlug: String!, $appSlug: String!) {
 	app(organizationSlug: $orgSlug, appSlug: $appSlug) {
 		id
 	}
@@ -31,7 +33,7 @@ func (s *Service) ReadApp(ctx context.Context, input ReadAppInput) (ReadAppOutpu
 	var resp appResponse
 
 	variables := map[string]any{"orgSlug": input.OrganizationSlug, "appSlug": input.AppSlug}
-	err := s.client.Exec(ctx, queryAppText, &resp, variables)
+	err := s.client.Exec(ctx, queryAppText, &resp, variables, graphql.OperationName("CLIAppRead"))
 	if err == nil {
 		return ReadAppOutput{AppID: resp.App.ID}, nil
 	}

--- a/internal/app/current_app_version.go
+++ b/internal/app/current_app_version.go
@@ -3,6 +3,8 @@ package app
 import (
 	"context"
 	"errors"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 var ErrNotDeployed = errors.New("app is not deployed")
@@ -17,7 +19,7 @@ type CurrentAppVersionOutput struct {
 }
 
 const queryCurrentAppVersionText = `
-query App($orgSlug: String!, $appSlug: String!) {
+query CLIReadCurrentAppVersion($orgSlug: String!, $appSlug: String!) {
 	app(organizationSlug: $orgSlug, appSlug: $appSlug) {
 		defaultDeployment {
 			current {
@@ -46,7 +48,7 @@ func (s *Service) CurrentAppVersion(ctx context.Context, input CurrentAppVersion
 	var resp currentAppVersionResponse
 
 	variables := map[string]any{"orgSlug": input.OrganizationSlug, "appSlug": input.AppSlug}
-	err := s.client.Exec(ctx, queryCurrentAppVersionText, &resp, variables)
+	err := s.client.Exec(ctx, queryCurrentAppVersionText, &resp, variables, graphql.OperationName("CLIReadCurrentAppVersion"))
 	if err != nil {
 		return CurrentAppVersionOutput{}, convertErrors(err)
 	}

--- a/internal/app/deploy_events.go
+++ b/internal/app/deploy_events.go
@@ -81,9 +81,9 @@ func (s *Service) DeployEvents(ctx context.Context, input DeployEventsInput) err
 		return nil
 	}
 
-	_, err := s.subscription.Subscribe(&DeployEventsSubscription{}, variables, handler)
+	_, err := s.subscription.Subscribe(&DeployEventsSubscription{}, variables, handler, graphql.OperationName("CLIAppDeployEvents"))
 	if err != nil {
-		return nil
+		return err
 	}
 
 	err = s.subscription.Run()

--- a/internal/app/version_create.go
+++ b/internal/app/version_create.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 type CreateAppVersionInput struct {
@@ -17,7 +19,7 @@ type CreateAppVersionOutput struct {
 }
 
 const appVersionCreateText = `
-mutation AppVersionCreate($appID: ID!, $version: String, $message: String!) {
+mutation CLIAppVersionCreate($appID: ID!, $version: String, $message: String!) {
 	appVersionCreate(appID: $appID, input: {version: $version, message: $message}) {
 		id
 	}
@@ -42,12 +44,10 @@ func (s *Service) CreateVersion(ctx context.Context, input CreateAppVersionInput
 		variables["version"] = input.Version
 	}
 
-	err := s.client.Exec(ctx, appVersionCreateText, &resp, variables)
+	err := s.client.Exec(ctx, appVersionCreateText, &resp, variables, graphql.OperationName("CLIAppVersionCreate"))
 	if err != nil {
 		return CreateAppVersionOutput{}, err
 	}
 
-	return CreateAppVersionOutput{
-		AppVersionID: resp.AppVersionCreate.ID,
-	}, nil
+	return CreateAppVersionOutput{AppVersionID: resp.AppVersionCreate.ID}, nil
 }

--- a/internal/app/version_download_url.go
+++ b/internal/app/version_download_url.go
@@ -1,6 +1,10 @@
 package app
 
-import "context"
+import (
+	"context"
+
+	"github.com/hasura/go-graphql-client"
+)
 
 type AppVersionDownloadURLInput struct {
 	AppVersionID string
@@ -11,7 +15,7 @@ type AppVersionDownloadURLOutput struct {
 }
 
 const appVersionDownloadURLText = `
-mutation AppVersionDownloadURL($appVersionID: ID!) {
+mutation CLIAppVersionDownloadURL($appVersionID: ID!) {
 	appVersionDownloadURL(appVersionID: $appVersionID) {
 		url
 	}
@@ -30,7 +34,7 @@ func (s *Service) AppVersionDownloadURL(ctx context.Context, input AppVersionDow
 	variables := map[string]any{
 		"appVersionID": input.AppVersionID,
 	}
-	err := s.client.Exec(ctx, appVersionDownloadURLText, &resp, variables)
+	err := s.client.Exec(ctx, appVersionDownloadURLText, &resp, variables, graphql.OperationName("CLIAppVersionDownloadURL"))
 	if err != nil {
 		return AppVersionDownloadURLOutput{}, convertErrors(err)
 	}

--- a/internal/app/version_upload_url.go
+++ b/internal/app/version_upload_url.go
@@ -2,6 +2,8 @@ package app
 
 import (
 	"context"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 type AppVersionUploadURLInput struct {
@@ -13,7 +15,7 @@ type AppVersionUploadURLOutput struct {
 }
 
 const appVersionUploadURLText = `
-mutation AppVersionUploadURL($appVersionID: ID!) {
+mutation CLIAppVersionUploadURL($appVersionID: ID!) {
 	appVersionUploadURL(appVersionID: $appVersionID) {
 		url
 	}
@@ -32,7 +34,7 @@ func (s *Service) AppVersionUploadURL(ctx context.Context, input AppVersionUploa
 	variables := map[string]any{
 		"appVersionID": input.AppVersionID,
 	}
-	err := s.client.Exec(ctx, appVersionUploadURLText, &resp, variables)
+	err := s.client.Exec(ctx, appVersionUploadURLText, &resp, variables, graphql.OperationName("CLIAppVersionUploadURL"))
 	if err != nil {
 		return AppVersionUploadURLOutput{}, err
 	}


### PR DESCRIPTION
Properly handles the `deploy` command `--project-dir` flag to allow deploying an app that exists within
a project directory.

Also:
* Fixes some linter issues related to format printing
* Adds improved traceability to the requests sent to the server by adding operation names