### PR TITLE
feat(cli): include ID in `organization list` output

### DIFF
--- a/cmd/legacy/delete/delete_test.go
+++ b/cmd/legacy/delete/delete_test.go
@@ -20,7 +20,7 @@ func TestAppDelete(t *testing.T) {
 			PublicURL: "https://test.com/public/another-hash",
 		}
 		appQueryResponse := test.AppToQueryResult("tool", app)
-		c, transportMock := test.CreateMockGqlClient(appQueryResponse, response)
+		c, transportMock := test.CreateMockGQLClient(appQueryResponse, response)
 		err := deleteApp(c, []string{})
 		assert.NoError(t, err)
 		transportMock.AssertExpectations(t)
@@ -29,7 +29,7 @@ func TestAppDelete(t *testing.T) {
 		test.ChdirToTmpDirWithAppIDDocument(t, dir.AppIDFileName, "id")
 		appNotFoundResponse := `"record not found"`
 		response, _ := test.DeleteFailureQueryResult(appNotFoundResponse)
-		c, transportMock := test.CreateMockGqlClient(response)
+		c, transportMock := test.CreateMockGQLClient(response)
 
 		err := deleteApp(c, []string{})
 
@@ -38,7 +38,7 @@ func TestAppDelete(t *testing.T) {
 	})
 
 	t.Run("returns error if app id document does not exists in the current directory", func(t *testing.T) {
-		c, transportMock := test.CreateMockGqlClient()
+		c, transportMock := test.CreateMockGQLClient()
 		err := deleteApp(c, []string{})
 
 		assert.Error(t, err)

--- a/cmd/legacy/list/list_test.go
+++ b/cmd/legacy/list/list_test.go
@@ -42,7 +42,7 @@ func TestList(t *testing.T) {
 				"tools": [` + strings.Join(appsAsStrings, ", ") + `]
 			}
 		}`
-		c, transportMock := test.CreateMockGqlClient(response)
+		c, transportMock := test.CreateMockGQLClient(response)
 
 		err := list(m, c)
 
@@ -56,7 +56,7 @@ func TestList(t *testing.T) {
 		m := new(auth.MockAuthenticator)
 		m.On("GetLoggedInUserFromKeyring").Return(u)
 
-		c, transportMock := test.CreateMockGqlClient()
+		c, transportMock := test.CreateMockGQLClient()
 
 		err := list(m, c)
 

--- a/cmd/legacy/publish/publish_test.go
+++ b/cmd/legacy/publish/publish_test.go
@@ -21,7 +21,7 @@ func TestAppPublish(t *testing.T) {
 		app.PublicURL = "https://test.com/public/another-hash"
 		appPublishResponse := test.AppToQueryResult("toolPublish", app)
 
-		c, transportMock := test.CreateMockGqlClient(appQueryResponse, appPublishResponse)
+		c, transportMock := test.CreateMockGQLClient(appQueryResponse, appPublishResponse)
 		err := publish(c)
 		assert.NoError(t, err)
 		transportMock.AssertExpectations(t)
@@ -30,7 +30,7 @@ func TestAppPublish(t *testing.T) {
 	t.Run("returns error if app does not exist", func(t *testing.T) {
 		test.ChdirToTmpDirWithAppIDDocument(t, dir.AppIDFileName, "id")
 		appNotFoundResponse := `{"errors":[{"message":"record not found","path":["tool"]}],"data":null}`
-		c, transportMock := test.CreateMockGqlClient(appNotFoundResponse)
+		c, transportMock := test.CreateMockGQLClient(appNotFoundResponse)
 
 		err := publish(c)
 
@@ -39,7 +39,7 @@ func TestAppPublish(t *testing.T) {
 	})
 
 	t.Run("returns error if app id document does not exists in the current directory", func(t *testing.T) {
-		c, transportMock := test.CreateMockGqlClient()
+		c, transportMock := test.CreateMockGQLClient()
 		err := publish(c)
 
 		assert.Error(t, err)
@@ -55,7 +55,7 @@ func TestAppPublish(t *testing.T) {
 		}
 		appQueryResponse := test.AppToQueryResult("tool", app)
 
-		c, transportMock := test.CreateMockGqlClient(appQueryResponse)
+		c, transportMock := test.CreateMockGQLClient(appQueryResponse)
 		err := publish(c)
 
 		assert.NoError(t, err)

--- a/cmd/legacy/unpublish/unpublish_test.go
+++ b/cmd/legacy/unpublish/unpublish_test.go
@@ -23,7 +23,7 @@ func TestAppPublish(t *testing.T) {
 		app.PublicURL = ""
 		appUnpublishResponse := test.AppToQueryResult("toolUnpublish", app)
 
-		c, transportMock := test.CreateMockGqlClient(appQueryResponse, appUnpublishResponse)
+		c, transportMock := test.CreateMockGQLClient(appQueryResponse, appUnpublishResponse)
 		err := unpublish(c)
 		assert.NoError(t, err)
 		transportMock.AssertExpectations(t)
@@ -32,7 +32,7 @@ func TestAppPublish(t *testing.T) {
 	t.Run("returns error if app does not exist", func(t *testing.T) {
 		test.ChdirToTmpDirWithAppIDDocument(t, dir.AppIDFileName, "id")
 		appNotFoundResponse := `{"errors":[{"message":"record not found","path":["tool"]}],"data":null}`
-		c, transportMock := test.CreateMockGqlClient(appNotFoundResponse)
+		c, transportMock := test.CreateMockGQLClient(appNotFoundResponse)
 
 		err := unpublish(c)
 
@@ -41,7 +41,7 @@ func TestAppPublish(t *testing.T) {
 	})
 
 	t.Run("returns error if app id document does not exists in the current directory", func(t *testing.T) {
-		c, transportMock := test.CreateMockGqlClient()
+		c, transportMock := test.CreateMockGQLClient()
 		err := unpublish(c)
 
 		assert.Error(t, err)
@@ -56,7 +56,7 @@ func TestAppPublish(t *testing.T) {
 		}
 		appQueryResponse := test.AppToQueryResult("tool", app)
 
-		c, transportMock := test.CreateMockGqlClient(appQueryResponse)
+		c, transportMock := test.CreateMockGQLClient(appQueryResponse)
 		err := unpublish(c)
 
 		assert.NoError(t, err)

--- a/cmd/organization/create/organization_create_test.go
+++ b/cmd/organization/create/organization_create_test.go
@@ -15,7 +15,7 @@ func TestOrganizationCreate(t *testing.T) {
 		m := new(auth.MockAuthenticator)
 		m.On("GetLoggedInUserFromKeyring").Return(u)
 
-		c, transportMock := test.CreateMockGqlClient()
+		c, transportMock := test.CreateMockGQLClient()
 
 		err := organizationCreate(m, c)
 

--- a/cmd/organization/list/organization_list_test.go
+++ b/cmd/organization/list/organization_list_test.go
@@ -53,7 +53,7 @@ func TestList(t *testing.T) {
 				}
 			}
 		}`
-		c, transportMock := test.CreateMockGqlClient(response)
+		c, transportMock := test.CreateMockGQLClient(response)
 
 		err := list(m, c)
 
@@ -67,7 +67,7 @@ func TestList(t *testing.T) {
 		m := new(auth.MockAuthenticator)
 		m.On("GetLoggedInUserFromKeyring").Return(u)
 
-		c, transportMock := test.CreateMockGqlClient()
+		c, transportMock := test.CreateMockGQLClient()
 
 		err := list(m, c)
 

--- a/cmd/organization/list/table.go
+++ b/cmd/organization/list/table.go
@@ -19,13 +19,14 @@ var (
 )
 
 func setupTable(organizations []organization.OrganizationMembership) *table.Table {
-	columns := []string{"Name", "Slug", "Role"}
+	columns := []string{"Name", "Slug", "Role", "ID"}
 	var rows [][]string
 	for _, o := range organizations {
 		rows = append(rows, []string{
 			o.Organization.Name,
 			o.Organization.Slug,
 			string(o.Role),
+			o.Organization.ID,
 		})
 	}
 

--- a/internal/test/gql_client.go
+++ b/internal/test/gql_client.go
@@ -36,7 +36,7 @@ func CreateTestGqlClient(t *testing.T, response string) *gqlclient.Client {
 	return gqlclient.New("http://localhost:8080", &http.Client{Transport: &ts})
 }
 
-func CreateMockGqlClient(responses ...string) (*gqlclient.Client, *MockTransport) {
+func CreateMockGQLClient(responses ...string) (*gqlclient.Client, *MockTransport) {
 	ts := MockTransport{}
 
 	for _, response := range responses {


### PR DESCRIPTION
* Adds an ID column in the table output of the `organization list` command.
* Renames `test.CreateMockGqlClient`  to `test.CreateMockGQLClient` to follow
  conventions of keepthe abbreviation.