### PR TITLE
feat(cli): configure default organization for commands

### DIFF
--- a/cmd/app/share/cmd.go
+++ b/cmd/app/share/cmd.go
@@ -1,27 +1,25 @@
 package share
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
 	"numerous.com/cli/cmd/args"
 	"numerous.com/cli/cmd/errorhandling"
+	"numerous.com/cli/cmd/usage"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/gql"
 )
 
-var long string = `Creates a shared URL for the specified app.
+const longFormat string = `Creates a shared URL for the specified app.
 
-If <name> and <organization> flags are set, they define the app
-to create a shared URL for.
-If they are not, the default deployment section in the manifest is used,
-if it is defined.
+%s
 
-If [app directory] is specified, that directory will be used to read the
-app manifest for the default deployment information.
-
-If no [app directory] is specified, the current working directory is used.
+%s
 `
+
+var long string = fmt.Sprintf(longFormat, usage.AppIdentifier("to create a shared URL for"), usage.AppDirectoryArgument)
 
 var Cmd = &cobra.Command{
 	Use:   "share [app directory]",

--- a/cmd/app/unshare/cmd.go
+++ b/cmd/app/unshare/cmd.go
@@ -1,27 +1,25 @@
 package unshare
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/spf13/cobra"
 	"numerous.com/cli/cmd/args"
 	"numerous.com/cli/cmd/errorhandling"
+	"numerous.com/cli/cmd/usage"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/gql"
 )
 
-var long string = `Removes a shared URL for the specified app.
+const longFormat string = `Removes a shared URL for the specified app.
 
-If <name> and <organization> flags are set, they define the app
-to remove a shared URL for.
-If they are not, the default deployment section in the manifest is used,
-if it is defined.
+%s
 
-If [app directory] is specified, that directory will be used to read the
-app manifest for the default deployment information.
-
-If no [app directory] is specified, the current working directory is used.
+%s
 `
+
+var long string = fmt.Sprintf(longFormat, usage.AppIdentifier("to remove a shared URL for"), usage.AppDirectoryArgument)
 
 var Cmd = &cobra.Command{
 	Use:   "unshare [app directory]",

--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+	"numerous.com/cli/cmd/config/set"
+	"numerous.com/cli/cmd/group"
+	"numerous.com/cli/cmd/output"
+	"numerous.com/cli/internal/config"
+)
+
+var Cmd = &cobra.Command{
+	GroupID: group.AdditionalCommandsGroupID,
+	Use:     "config",
+	Short:   "Configure the Numerous CLI",
+	Long:    "Set configuration values, or print the entire configuration.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) != 0 {
+			// do nothing if subcommand is running
+			return nil
+		}
+
+		cfg := config.Config{}
+		if err := cfg.Load(); err != nil {
+			output.PrintErrorDetails("Error loading configuration", err)
+			return err
+		}
+
+		cfg.Print()
+
+		return nil
+	},
+}
+
+func init() {
+	Cmd.AddCommand(set.Cmd)
+}

--- a/cmd/config/set/cmd.go
+++ b/cmd/config/set/cmd.go
@@ -1,0 +1,16 @@
+package set
+
+import (
+	"github.com/spf13/cobra"
+	"numerous.com/cli/cmd/errorhandling"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "set",
+	Short: "Set a configuration value",
+	RunE:  run,
+}
+
+func run(cmd *cobra.Command, args []string) error {
+	return errorhandling.ErrorAlreadyPrinted(configSet(args))
+}

--- a/cmd/config/set/config_set.go
+++ b/cmd/config/set/config_set.go
@@ -1,0 +1,44 @@
+package set
+
+import (
+	"errors"
+
+	"numerous.com/cli/cmd/output"
+	"numerous.com/cli/internal/config"
+)
+
+var (
+	ErrInvalidPropertyToSet = errors.New("invalid property to set")
+	ErrInvalidArgumentCount = errors.New("expected exactly two arguments")
+)
+
+func configSet(args []string) error {
+	if len(args) != 2 { // nolint:mnd
+		output.PrintError("Expected exactly two arguments, got %d", "", len(args))
+		return ErrInvalidArgumentCount
+	}
+	property, value := args[0], args[1]
+
+	cfg := config.Config{}
+	if err := cfg.Load(); err != nil {
+		output.PrintErrorDetails("Error loading configuration", err)
+		return err
+	}
+
+	switch property {
+	case "organization":
+		cfg.OrganizationSlug = value
+	default:
+		output.PrintError("Invalid property to set: %q", "", property)
+		return ErrInvalidPropertyToSet
+	}
+
+	if err := cfg.Save(); err != nil {
+		output.PrintErrorDetails("Error saving configuration", err)
+		return err
+	}
+
+	output.PrintlnOK("Set %s=%s", property, value)
+
+	return nil
+}

--- a/cmd/config/set/config_set.go
+++ b/cmd/config/set/config_set.go
@@ -38,7 +38,7 @@ func configSet(args []string) error {
 		return err
 	}
 
-	output.PrintlnOK("Set %s=%s", property, value)
+	output.PrintlnOK("Set %s=%q", property, value)
 
 	return nil
 }

--- a/cmd/deletecmd/cmd.go
+++ b/cmd/deletecmd/cmd.go
@@ -1,12 +1,14 @@
 package deletecmd
 
 import (
+	"fmt"
 	"net/http"
 
 	"numerous.com/cli/cmd/args"
 	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/group"
 	"numerous.com/cli/cmd/output"
+	"numerous.com/cli/cmd/usage"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/dir"
 	"numerous.com/cli/internal/gql"
@@ -24,16 +26,14 @@ var Cmd = &cobra.Command{
 	Args:    args.OptionalAppDir(&appDir),
 }
 
-const long = `Deletes the specified app from the organization.
+const longFormat = `Deletes the specified app from the organization.
 
-If <app> and <organization> flags are set, they define the app to delete. If
-they are not the default deployment section in the manifest is used if it is
-defined.
+%s
 
-If [app directory] is specified, that directory will be used to read the
-app manifest for the default deployment information.
+%s
+`
 
-If no [app directory] is specified, the current working directory is used.`
+var long string = fmt.Sprintf(longFormat, usage.AppIdentifier("to delete"), usage.AppDirectoryArgument)
 
 const example = `To delete an app use the following form:
 

--- a/cmd/deploy/cmd.go
+++ b/cmd/deploy/cmd.go
@@ -1,34 +1,37 @@
 package deploy
 
 import (
+	"fmt"
 	"net/http"
 
 	"numerous.com/cli/cmd/args"
 	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/group"
+	"numerous.com/cli/cmd/usage"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/gql"
 
 	"github.com/spf13/cobra"
 )
 
+const longFormat string = `Deploys an application to an organization on the Numerous platform.
+
+After deployment the deployed version of the app is available in the
+organization's apps page.
+
+%s
+
+%s
+`
+
+var long string = fmt.Sprintf(longFormat, usage.AppIdentifier("to deploy"), usage.AppDirectoryArgument)
+
 var Cmd = &cobra.Command{
 	Use:     "deploy [app directory]",
 	RunE:    run,
 	GroupID: group.AppCommandsGroupID,
 	Short:   "Deploy an app to an organization",
-	Long: `Deploys an application to an organization on the Numerous platform.
-
-An app's deployment is identified with the <name> and <organization> identifier.
-Deploying an app to a given <name> and <organization> combination, will override
-the existing version.
-
-The <name> must contain only lower-case alphanumeric characters and dashes.
-
-After deployment the deployed version of the app is available in the
-organization's apps page.
-
-If no [app directory] is specified, the current working directory is used.`,
+	Long:    long,
 	Example: `
 If an app has been initialized in the current working directory, and it should
 be pushed to the organization "organization-slug-a2ecf59b", and the app slug

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"context"
 	"io"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDeploy(t *testing.T) {
@@ -233,8 +231,7 @@ func TestDeploy(t *testing.T) {
 		})
 
 		input := DeployInput{AppDir: appDir, OrgSlug: slug, AppSlug: appSlug, Version: expectedVersion, Message: expectedMessage, Verbose: true}
-
-		stdout, err := mockStdout(t, func() error {
+		stdoutR, err := test.RunWithPatchedStdout(t, func() error {
 			return Deploy(context.TODO(), apps, input)
 		})
 
@@ -263,7 +260,7 @@ func TestDeploy(t *testing.T) {
 			"Or you can use the --follow flag:\n",
 			"  numerous deploy --follow --organization=organization-slug --app=app-slug " + appDir + "\n",
 		}
-		output, _ := io.ReadAll(stdout)
+		output, _ := io.ReadAll(stdoutR)
 		actual := cleanNonASCIIAndANSI(string(output))
 		assert.Equal(t, strings.Join(expected, ""), actual)
 	})
@@ -283,12 +280,12 @@ func TestDeploy(t *testing.T) {
 		apps.On("AppDeployLogs", appident.AppIdentifier{OrganizationSlug: slug, AppSlug: appSlug}).Once().Return(ch, nil)
 
 		input := DeployInput{AppDir: appDir, OrgSlug: slug, AppSlug: appSlug, Version: expectedVersion, Message: expectedMessage, Verbose: true, Follow: true}
-		stdout, err := mockStdout(t, func() error {
+		stdoutR, err := test.RunWithPatchedStdout(t, func() error {
 			return Deploy(context.TODO(), apps, input)
 		})
 
 		assert.NoError(t, err)
-		output, _ := io.ReadAll(stdout)
+		output, _ := io.ReadAll(stdoutR)
 		actual := cleanNonASCIIAndANSI(string(output))
 
 		expected := strings.Join(
@@ -319,24 +316,4 @@ func cleanNonASCIIAndANSI(s string) string {
 	}
 
 	return cleaned
-}
-
-func mockStdout(t *testing.T, f func() error) (io.Reader, error) {
-	t.Helper()
-
-	realStdout := os.Stdout
-
-	defer func() {
-		os.Stdout = realStdout
-	}()
-
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-
-	err = f()
-
-	require.NoError(t, w.Close())
-
-	return r, err
 }

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -11,6 +11,7 @@ import (
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/appident"
+	"numerous.com/cli/internal/config"
 	"numerous.com/cli/internal/test"
 
 	"github.com/stretchr/testify/assert"
@@ -101,7 +102,12 @@ func TestDeploy(t *testing.T) {
 		assert.ErrorIs(t, err, appident.ErrInvalidOrganizationSlug)
 	})
 
-	t.Run("given no slug argument and no manifest deployment then it returns error", func(t *testing.T) {
+	t.Run("given no slug argument, no manifest deployment and no config then it returns error", func(t *testing.T) {
+		oldConfigBaseDir := config.OverrideConfigBaseDir(t.TempDir())
+		t.Cleanup(func() {
+			config.OverrideConfigBaseDir(oldConfigBaseDir)
+		})
+
 		appDir := t.TempDir()
 		test.CopyDir(t, "../../testdata/streamlit_app_without_deploy", appDir)
 

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -231,7 +231,7 @@ func TestDeploy(t *testing.T) {
 		})
 
 		input := DeployInput{AppDir: appDir, OrgSlug: slug, AppSlug: appSlug, Version: expectedVersion, Message: expectedMessage, Verbose: true}
-		stdoutR, err := test.RunWithPatchedStdout(t, func() error {
+		stdoutR, err := test.RunEWithPatchedStdout(t, func() error {
 			return Deploy(context.TODO(), apps, input)
 		})
 
@@ -280,7 +280,7 @@ func TestDeploy(t *testing.T) {
 		apps.On("AppDeployLogs", appident.AppIdentifier{OrganizationSlug: slug, AppSlug: appSlug}).Once().Return(ch, nil)
 
 		input := DeployInput{AppDir: appDir, OrgSlug: slug, AppSlug: appSlug, Version: expectedVersion, Message: expectedMessage, Verbose: true, Follow: true}
-		stdoutR, err := test.RunWithPatchedStdout(t, func() error {
+		stdoutR, err := test.RunEWithPatchedStdout(t, func() error {
 			return Deploy(context.TODO(), apps, input)
 		})
 

--- a/cmd/logs/logs_test.go
+++ b/cmd/logs/logs_test.go
@@ -8,6 +8,7 @@ import (
 
 	"numerous.com/cli/internal/app"
 	"numerous.com/cli/internal/appident"
+	"numerous.com/cli/internal/config"
 	"numerous.com/cli/internal/test"
 
 	"github.com/stretchr/testify/assert"
@@ -33,7 +34,12 @@ func TestLogs(t *testing.T) {
 		assert.ErrorIs(t, err, appident.ErrInvalidAppSlug)
 	})
 
-	t.Run("given neither slug nor app slug arguments and numerous.toml without deploy then it returns error", func(t *testing.T) {
+	t.Run("given neither slug nor app slug arguments, numerous.toml without deploy and no config then it returns error", func(t *testing.T) {
+		oldConfigBaseDir := config.OverrideConfigBaseDir(t.TempDir())
+		t.Cleanup(func() {
+			config.OverrideConfigBaseDir(oldConfigBaseDir)
+		})
+
 		appDir := t.TempDir()
 		test.CopyDir(t, "../../testdata/streamlit_app_without_deploy", appDir)
 

--- a/cmd/organization/list/display_list.go
+++ b/cmd/organization/list/display_list.go
@@ -3,10 +3,11 @@ package list
 import (
 	"fmt"
 
+	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/gql/organization"
 )
 
-func displayList(memberships []organization.OrganizationMembership) {
+func displayList(memberships []organization.OrganizationMembership, configuredOrganizationSlug string) {
 	first := true
 	for _, membership := range memberships {
 		if first {
@@ -15,16 +16,24 @@ func displayList(memberships []organization.OrganizationMembership) {
 			fmt.Println()
 		}
 
-		displayMembership(membership)
+		displayMembership(membership, configuredOrganizationSlug)
 	}
 }
 
-func displayMembership(membership organization.OrganizationMembership) {
+func displayMembership(membership organization.OrganizationMembership, configuredOrganizationSlug string) {
 	o := membership.Organization
 	role := membership.Role
 
-	fmt.Printf("Name: %s\n", o.Name)
-	fmt.Printf("Slug: %s\n", o.Slug)
-	fmt.Printf("Role: %s\n", role)
-	fmt.Printf("ID:   %s\n", o.ID)
+	if configuredOrganizationSlug == o.Slug {
+		fmt.Printf("Name:    %s\n", o.Name)
+		fmt.Printf("Slug:    %s\n", o.Slug)
+		fmt.Printf("Role:    %s\n", role)
+		fmt.Printf("ID:      %s\n", o.ID)
+		fmt.Println("Default: " + output.AnsiGreen + "Yes" + output.AnsiReset)
+	} else {
+		fmt.Printf("Name: %s\n", o.Name)
+		fmt.Printf("Slug: %s\n", o.Slug)
+		fmt.Printf("Role: %s\n", role)
+		fmt.Printf("ID:   %s\n", o.ID)
+	}
 }

--- a/cmd/organization/list/display_table.go
+++ b/cmd/organization/list/display_table.go
@@ -20,15 +20,20 @@ var (
 	rowStyle = lipgloss.NewStyle().Padding(0, 1)
 )
 
-func setupTable(organizations []organization.OrganizationMembership) *table.Table {
-	columns := []string{"Name", "Slug", "Role", "ID"}
+func setupTable(organizations []organization.OrganizationMembership, configuredOrganizationSlug string) *table.Table {
+	columns := []string{"Name", "Slug", "Role", "ID", "Default"}
 	var rows [][]string
 	for _, o := range organizations {
+		isDefault := ""
+		if o.Organization.Slug == configuredOrganizationSlug {
+			isDefault = "*"
+		}
 		rows = append(rows, []string{
 			o.Organization.Name,
 			o.Organization.Slug,
 			string(o.Role),
 			o.Organization.ID,
+			isDefault,
 		})
 	}
 
@@ -52,6 +57,6 @@ func setupTable(organizations []organization.OrganizationMembership) *table.Tabl
 	return t
 }
 
-func displayTable(organizations []organization.OrganizationMembership) {
-	fmt.Println(setupTable(organizations))
+func displayTable(organizations []organization.OrganizationMembership, configuredOrganizationSlug string) {
+	fmt.Println(setupTable(organizations, configuredOrganizationSlug))
 }

--- a/cmd/organization/list/organization_list.go
+++ b/cmd/organization/list/organization_list.go
@@ -4,6 +4,7 @@ import (
 	"numerous.com/cli/cmd/errorhandling"
 	"numerous.com/cli/cmd/output"
 	"numerous.com/cli/internal/auth"
+	"numerous.com/cli/internal/config"
 	"numerous.com/cli/internal/gql"
 	"numerous.com/cli/internal/gql/user"
 
@@ -40,11 +41,13 @@ func list(a auth.Authenticator, g *gqlclient.Client) error {
 		return err
 	}
 
+	configuredOrganization := config.OrganizationSlug()
+
 	switch displayMode {
 	case DisplayModeList:
-		displayList(userResp.Memberships)
+		displayList(userResp.Memberships, configuredOrganization)
 	case DisplayModeTable:
-		displayTable(userResp.Memberships)
+		displayTable(userResp.Memberships, configuredOrganization)
 	default:
 		output.PrintError("Unexpected display mode %q", "", displayMode)
 		return errInvalidDisplayMode

--- a/cmd/output/task_test.go
+++ b/cmd/output/task_test.go
@@ -316,11 +316,10 @@ func TestTask(t *testing.T) {
 
 	t.Run("StartTask", func(t *testing.T) {
 		t.Run("writes expected output to stdout", func(t *testing.T) {
-			stdoutR, stdoutW := test.PatchStdout(t)
+			stdoutR := test.RunWithPatchedStdout(t, func() {
+				StartTask("message")
+			})
 
-			StartTask("message")
-
-			assert.NoError(t, stdoutW.Close())
 			actual, err := io.ReadAll(stdoutR)
 			assert.NoError(t, err)
 			expected := hourglassIcon + " message" + AnsiFaint + ".............................................." + AnsiReset

--- a/cmd/output/task_test.go
+++ b/cmd/output/task_test.go
@@ -4,12 +4,11 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"numerous.com/cli/internal/test"
 )
 
 var errTest = errors.New("test error")
@@ -317,17 +316,12 @@ func TestTask(t *testing.T) {
 
 	t.Run("StartTask", func(t *testing.T) {
 		t.Run("writes expected output to stdout", func(t *testing.T) {
-			// replace stdout with a pipe that we can read
-			stdout := os.Stdout
-			defer func() { os.Stdout = stdout }() // restore stdout afterwards
-			r, w, err := os.Pipe()
-			require.NoError(t, err)
-			os.Stdout = w
+			stdoutR, stdoutW := test.PatchStdout(t)
 
 			StartTask("message")
 
-			assert.NoError(t, w.Close())
-			actual, err := io.ReadAll(r)
+			assert.NoError(t, stdoutW.Close())
+			actual, err := io.ReadAll(stdoutR)
 			assert.NoError(t, err)
 			expected := hourglassIcon + " message" + AnsiFaint + ".............................................." + AnsiReset
 			assert.Equal(t, expected, string(actual))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"numerous.com/cli/cmd/app"
+	"numerous.com/cli/cmd/config"
 	"numerous.com/cli/cmd/deletecmd"
 	"numerous.com/cli/cmd/deploy"
 	"numerous.com/cli/cmd/download"
@@ -149,6 +150,7 @@ func init() {
 		token.Cmd,
 		version.Cmd,
 		app.Cmd,
+		config.Cmd,
 
 		// dummy commands to display helpful messages for legacy commands
 		dummyLegacyCmd("push"),

--- a/cmd/usage/app_directory_arg.go
+++ b/cmd/usage/app_directory_arg.go
@@ -1,0 +1,6 @@
+package usage
+
+const AppDirectoryArgument string = `If [app directory] is specified, that directory will be used to read the
+app manifest for the default deployment information.
+
+If no [app directory] is specified, the current working directory is used.`

--- a/cmd/usage/app_identifier.go
+++ b/cmd/usage/app_identifier.go
@@ -1,0 +1,18 @@
+package usage
+
+import "fmt"
+
+const appIdentifierFormat string = `The app %s is specified firstly by --app and
+--organization flags, secondly by the deployment section in the manifest
+(numerous.toml), and finally by the local configuration (see "numerous config").
+
+If no app is identified either by --app or by the default deployment section in
+the manifest, the app name in the manifest is converted into a slug, e.g.
+"My Awesome App" would become "my-awesome-app".
+
+App and organization identifiers must contain only lower-case alphanumeric
+characters and dashes.`
+
+func AppIdentifier(action string) string {
+	return fmt.Sprintf(appIdentifierFormat, action)
+}

--- a/internal/appident/get_appidentifier.go
+++ b/internal/appident/get_appidentifier.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"numerous.com/cli/cmd/validate"
+	"numerous.com/cli/internal/config"
 	"numerous.com/cli/internal/manifest"
 )
 
@@ -52,6 +53,10 @@ func GetAppIdentifier(appDir string, m *manifest.Manifest, orgSlug string, appSl
 
 		orgSlug = GetOrgSlug(m, orgSlug)
 		appSlug = GetAppSlug(m, appSlug)
+	}
+
+	if orgSlug == "" {
+		orgSlug = config.OrganizationSlug()
 	}
 
 	ai := AppIdentifier{OrganizationSlug: orgSlug, AppSlug: appSlug}

--- a/internal/appident/get_appidentifier_test.go
+++ b/internal/appident/get_appidentifier_test.go
@@ -1,26 +1,26 @@
 package appident
 
 import (
+	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"numerous.com/cli/internal/config"
+	"numerous.com/cli/internal/manifest"
 	"numerous.com/cli/internal/test"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetAppIdentifier(t *testing.T) {
 	const orgSlug = "organization-slug"
 	const appSlug = "app-slug"
-	expected := AppIdentifier{OrganizationSlug: orgSlug, AppSlug: appSlug}
-
-	t.Run("given valid slug and app slug then they are returned", func(t *testing.T) {
-		actual, err := GetAppIdentifier("", nil, orgSlug, appSlug)
-
-		assert.Equal(t, expected, actual)
-		assert.NoError(t, err)
-	})
 
 	t.Run("given invalid organization slug then invalid organization slug error is returned", func(t *testing.T) {
+		config.OverrideConfigBaseDir(t.TempDir())
+
 		actual, err := GetAppIdentifier("", nil, "Some Invalid Organization Slug", appSlug)
 
 		assert.Equal(t, AppIdentifier{OrganizationSlug: "Some Invalid Organization Slug", AppSlug: appSlug}, actual)
@@ -28,25 +28,139 @@ func TestGetAppIdentifier(t *testing.T) {
 	})
 
 	t.Run("given invalid app slug then invalid app slug error is returned", func(t *testing.T) {
+		config.OverrideConfigBaseDir(t.TempDir())
+
 		actual, err := GetAppIdentifier("", nil, orgSlug, "Some Invalid App Slug")
 
 		assert.Equal(t, AppIdentifier{OrganizationSlug: orgSlug, AppSlug: "Some Invalid App Slug"}, actual)
 		assert.ErrorIs(t, err, ErrInvalidAppSlug)
 	})
 
-	t.Run("given app dir but no slug and no app slug then it is loaded from manifest", func(t *testing.T) {
+	t.Run("given error loading manifest and no app slug argument then error is returned", func(t *testing.T) {
+		config.OverrideConfigBaseDir(t.TempDir())
 		appDir := t.TempDir()
-		test.CopyDir(t, "../../testdata/streamlit_app", appDir)
+		// ensure error loading manifest by creating a folder at the manifest
+		// location
+		require.NoError(t, os.MkdirAll(appDir, fs.ModeDir))
 
 		actual, err := GetAppIdentifier(appDir, nil, "", "")
 
-		expected := AppIdentifier{
-			OrganizationSlug: "organization-slug-in-manifest",
-			AppSlug:          "app-slug-in-manifest",
-		}
-		assert.Equal(t, expected, actual)
-		assert.NoError(t, err)
+		assert.Empty(t, actual)
+		assert.ErrorIs(t, err, ErrAppNotInitialized)
 	})
+
+	type testCase struct {
+		name   string
+		argOrg string
+		argApp string
+		// manifest that is passed directly to the function
+		manifestPreloaded *manifest.Manifest
+		// manifest that is stored in the app folder
+		manifestSaved *manifest.Manifest
+		configOrg     string
+		expected      AppIdentifier
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:          "given valid arguments they are returned",
+			argOrg:        "arg-org-slug",
+			argApp:        "arg-app-slug",
+			manifestSaved: &manifest.Manifest{Deployment: &manifest.Deployment{OrganizationSlug: "manifest-org-slug", AppSlug: "manifest-app-slug"}},
+			configOrg:     "config-org-slug",
+			expected: AppIdentifier{
+				OrganizationSlug: "arg-org-slug",
+				AppSlug:          "arg-app-slug",
+			},
+		},
+		{
+			name:      "given no organization in args or manifest it falls back to organization from config",
+			argApp:    "arg-app-slug",
+			configOrg: "config-org-slug",
+			expected: AppIdentifier{
+				OrganizationSlug: "config-org-slug",
+				AppSlug:          "arg-app-slug",
+			},
+		},
+		{
+			name:          "given no organization in args it falls back to organization from loaded manifest",
+			argApp:        "arg-app-slug",
+			manifestSaved: &manifest.Manifest{Deployment: &manifest.Deployment{OrganizationSlug: "manifest-org-slug", AppSlug: "manifest-app-slug"}},
+			expected: AppIdentifier{
+				OrganizationSlug: "manifest-org-slug",
+				AppSlug:          "arg-app-slug",
+			},
+		},
+		{
+			name:              "given no organization in args it falls back to organization from preloaded manifest",
+			argApp:            "arg-app-slug",
+			manifestPreloaded: &manifest.Manifest{Deployment: &manifest.Deployment{OrganizationSlug: "manifest-org-slug", AppSlug: "manifest-app-slug"}},
+			expected: AppIdentifier{
+				OrganizationSlug: "manifest-org-slug",
+				AppSlug:          "arg-app-slug",
+			},
+		},
+		{
+			name:          "given no app in args it falls back to app from loaded manifest",
+			argOrg:        "arg-org-slug",
+			manifestSaved: &manifest.Manifest{Deployment: &manifest.Deployment{OrganizationSlug: "manifest-org-slug", AppSlug: "manifest-app-slug"}},
+			expected: AppIdentifier{
+				OrganizationSlug: "arg-org-slug",
+				AppSlug:          "manifest-app-slug",
+			},
+		},
+		{
+			name:              "given no organization in args it falls back to organization from preloaded manifest",
+			argOrg:            "arg-org-slug",
+			manifestPreloaded: &manifest.Manifest{Deployment: &manifest.Deployment{OrganizationSlug: "manifest-org-slug", AppSlug: "manifest-app-slug"}},
+			expected: AppIdentifier{
+				OrganizationSlug: "arg-org-slug",
+				AppSlug:          "manifest-app-slug",
+			},
+		},
+		{
+			name:              "given no app slug in args or manifest it falls back to converted preloaded manifest app name",
+			argOrg:            "arg-org-slug",
+			manifestPreloaded: &manifest.Manifest{App: manifest.App{Name: "App Name"}},
+			expected: AppIdentifier{
+				OrganizationSlug: "arg-org-slug",
+				AppSlug:          "app-name",
+			},
+		},
+		{
+			name:          "given no app slug in args or manifest it falls back to converted loaded manifest app name",
+			argOrg:        "arg-org-slug",
+			manifestSaved: &manifest.Manifest{App: manifest.App{Name: "App Name"}},
+			expected: AppIdentifier{
+				OrganizationSlug: "arg-org-slug",
+				AppSlug:          "app-name",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			appDir := t.TempDir()
+
+			// setup config
+			configDir := t.TempDir()
+			config.OverrideConfigBaseDir(configDir)
+			if tc.configOrg != "" {
+				cfg := config.Config{OrganizationSlug: tc.configOrg}
+				require.NoError(t, cfg.Save())
+			}
+
+			// setup saved manifest
+			if tc.manifestSaved != nil {
+				mToml, err := tc.manifestSaved.ToTOML()
+				require.NoError(t, err)
+				test.WriteFile(t, filepath.Join(appDir, manifest.ManifestFileName), []byte(mToml))
+			}
+
+			actual, err := GetAppIdentifier(appDir, tc.manifestPreloaded, tc.argOrg, tc.argApp)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
 }
 
 func TestManifestAppNameToAppSlug(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,9 @@
+package config
+
+import "errors"
+
+var ErrNoConfigDirDefined = errors.New("no config directory is defined")
+
+type Config struct {
+	OrganizationSlug string `toml:"organization,omitempty"`
+}

--- a/internal/config/config_dir.go
+++ b/internal/config/config_dir.go
@@ -1,0 +1,3 @@
+package config
+
+var configBaseDir string

--- a/internal/config/config_dir.go
+++ b/internal/config/config_dir.go
@@ -1,3 +1,11 @@
 package config
 
 var configBaseDir string
+
+// Set the config base directory, and return the old value.
+func OverrideConfigBaseDir(newValue string) string {
+	oldValue := configBaseDir
+	configBaseDir = newValue
+
+	return oldValue
+}

--- a/internal/config/config_dir_darwin.go
+++ b/internal/config/config_dir_darwin.go
@@ -1,0 +1,10 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	configBaseDir = filepath.Join(os.Getenv("HOME"), "Library", "Application Support")
+}

--- a/internal/config/config_dir_linux.go
+++ b/internal/config/config_dir_linux.go
@@ -1,0 +1,15 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome != "" {
+		configBaseDir = xdgConfigHome
+	} else {
+		configBaseDir = filepath.Join(os.Getenv("HOME"), ".config")
+	}
+}

--- a/internal/config/config_dir_windows.go
+++ b/internal/config/config_dir_windows.go
@@ -1,0 +1,9 @@
+package config
+
+import (
+	"os"
+)
+
+func init() {
+	configBaseDir = os.Getenv("APPDATA")
+}

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -1,0 +1,19 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+const configDirPerm os.FileMode = 0o755
+
+func (c *Config) configFilePath() (string, error) {
+	numerousConfigDir := filepath.Join(configBaseDir, "numerous")
+	if _, err := os.Stat(numerousConfigDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(numerousConfigDir, configDirPerm); err != nil {
+			return "", err
+		}
+	}
+
+	return filepath.Join(numerousConfigDir, "config.toml"), nil
+}

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -9,10 +9,8 @@ const configDirPerm os.FileMode = 0o755
 
 func (c *Config) configFilePath() (string, error) {
 	numerousConfigDir := filepath.Join(configBaseDir, "numerous")
-	if _, err := os.Stat(numerousConfigDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(numerousConfigDir, configDirPerm); err != nil {
-			return "", err
-		}
+	if err := os.MkdirAll(numerousConfigDir, configDirPerm); err != nil {
+		return "", err
 	}
 
 	return filepath.Join(numerousConfigDir, "config.toml"), nil

--- a/internal/config/config_load.go
+++ b/internal/config/config_load.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"errors"
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+func (c *Config) Load() error {
+	path, err := c.configFilePath()
+	if err != nil {
+		return err
+	}
+
+	r, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	_, err = toml.NewDecoder(r).Decode(c)
+
+	return err
+}

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,5 +42,16 @@ func TestLoad(t *testing.T) {
 		expected := Config{OrganizationSlug: "organization-slug"}
 		assert.NoError(t, err)
 		assert.Equal(t, expected, cfg)
+	})
+
+	t.Run("returns error if it cannot create config file", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+		cfg := Config{}
+		require.NoError(t, os.WriteFile(filepath.Join(configBaseDir, "numerous"), []byte{}, configPerm))
+
+		err := cfg.Load()
+
+		assert.EqualError(t, err, fmt.Sprintf("mkdir %s: not a directory", filepath.Join(configBaseDir, "numerous")))
+		assert.Empty(t, cfg)
 	})
 }

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	t.Run("returns empty config if file does not exist", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+		cfg := Config{}
+
+		err := cfg.Load()
+
+		assert.NoError(t, err)
+		assert.Empty(t, cfg)
+	})
+
+	t.Run("returns empty config if directory does not exist", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+		cfg := Config{}
+
+		err := cfg.Load()
+
+		assert.NoError(t, err)
+		assert.Empty(t, cfg)
+	})
+
+	t.Run("returns expected config", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+		cfg := Config{}
+		require.NoError(t, os.Mkdir(filepath.Join(configBaseDir, "numerous"), configDirPerm))
+		require.NoError(t, os.WriteFile(filepath.Join(configBaseDir, "numerous", "config.toml"), []byte("organization = \"organization-slug\""), configPerm))
+
+		err := cfg.Load()
+
+		expected := Config{OrganizationSlug: "organization-slug"}
+		assert.NoError(t, err)
+		assert.Equal(t, expected, cfg)
+	})
+}

--- a/internal/config/config_organization_slug.go
+++ b/internal/config/config_organization_slug.go
@@ -1,0 +1,11 @@
+package config
+
+func OrganizationSlug() string {
+	c := Config{}
+
+	if err := c.Load(); err != nil {
+		return ""
+	}
+
+	return c.OrganizationSlug
+}

--- a/internal/config/config_organization_slug_test.go
+++ b/internal/config/config_organization_slug_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationSlug(t *testing.T) {
+	configBaseDir = t.TempDir()
+	testOrganizationSlug := "test-organization-slug"
+	c := Config{OrganizationSlug: testOrganizationSlug}
+	require.NoError(t, c.Save())
+
+	assert.Equal(t, testOrganizationSlug, OrganizationSlug())
+}

--- a/internal/config/config_print.go
+++ b/internal/config/config_print.go
@@ -1,0 +1,11 @@
+package config
+
+import (
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+func (c *Config) Print() {
+	toml.NewEncoder(os.Stdout).Encode(c) // nolint:errcheck
+}

--- a/internal/config/config_print_test.go
+++ b/internal/config/config_print_test.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"numerous.com/cli/internal/test"
+)
+
+func TestPrint(t *testing.T) {
+	stdoutR, stdoutW := test.PatchStdout(t)
+
+	c := Config{OrganizationSlug: "test-organization-slug"}
+	c.Print()
+
+	assert.NoError(t, stdoutW.Close())
+	data, err := io.ReadAll(stdoutR)
+
+	if assert.NoError(t, err) {
+		expected := "organization = \"test-organization-slug\"\n"
+		assert.Equal(t, expected, string(data))
+	}
+}

--- a/internal/config/config_print_test.go
+++ b/internal/config/config_print_test.go
@@ -9,14 +9,13 @@ import (
 )
 
 func TestPrint(t *testing.T) {
-	stdoutR, stdoutW := test.PatchStdout(t)
-
 	c := Config{OrganizationSlug: "test-organization-slug"}
-	c.Print()
 
-	assert.NoError(t, stdoutW.Close())
+	stdoutR := test.RunWithPatchedStdout(t, func() {
+		c.Print()
+	})
+
 	data, err := io.ReadAll(stdoutR)
-
 	if assert.NoError(t, err) {
 		expected := "organization = \"test-organization-slug\"\n"
 		assert.Equal(t, expected, string(data))

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -18,6 +18,7 @@ func (c *Config) Save() error {
 	if err != nil {
 		return err
 	}
+	defer w.Close()
 
 	return toml.NewEncoder(w).Encode(c)
 }

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -1,0 +1,23 @@
+package config
+
+import (
+	"os"
+
+	"github.com/BurntSushi/toml"
+)
+
+const configPerm os.FileMode = 0o640
+
+func (c *Config) Save() error {
+	path, err := c.configFilePath()
+	if err != nil {
+		return err
+	}
+
+	w, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, configPerm)
+	if err != nil {
+		return err
+	}
+
+	return toml.NewEncoder(w).Encode(c)
+}

--- a/internal/config/config_save.go
+++ b/internal/config/config_save.go
@@ -14,7 +14,7 @@ func (c *Config) Save() error {
 		return err
 	}
 
-	w, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, configPerm)
+	w, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, configPerm)
 	if err != nil {
 		return err
 	}

--- a/internal/config/config_save_test.go
+++ b/internal/config/config_save_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSave(t *testing.T) {
+	t.Run("saves expected file", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+
+		cfg := Config{OrganizationSlug: "test-organization-slug"}
+		err := cfg.Save()
+
+		assert.NoError(t, err)
+		actual, err := os.ReadFile(filepath.Join(configBaseDir, "numerous", "config.toml"))
+		if assert.NoError(t, err) {
+			expected := "organization = \"test-organization-slug\"\n"
+			assert.Equal(t, expected, string(actual))
+		}
+	})
+}

--- a/internal/config/config_save_test.go
+++ b/internal/config/config_save_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,5 +40,15 @@ func TestSave(t *testing.T) {
 			expected := "organization = \"test-shorter-org-slug\"\n"
 			assert.Equal(t, expected, string(actual))
 		}
+	})
+
+	t.Run("returns error if it cannot create config file", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(configBaseDir, "numerous"), []byte{}, configPerm))
+
+		cfg := Config{OrganizationSlug: "test-organization-slug"}
+		err := cfg.Save()
+
+		assert.EqualError(t, err, fmt.Sprintf("mkdir %s: not a directory", filepath.Join(configBaseDir, "numerous")))
 	})
 }

--- a/internal/config/config_save_test.go
+++ b/internal/config/config_save_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSave(t *testing.T) {
@@ -19,6 +20,23 @@ func TestSave(t *testing.T) {
 		actual, err := os.ReadFile(filepath.Join(configBaseDir, "numerous", "config.toml"))
 		if assert.NoError(t, err) {
 			expected := "organization = \"test-organization-slug\"\n"
+			assert.Equal(t, expected, string(actual))
+		}
+	})
+
+	t.Run("truncates configuration file before saving", func(t *testing.T) {
+		configBaseDir = t.TempDir()
+		cfg := Config{OrganizationSlug: "test-very-long-organization-slug"}
+		err := cfg.Save()
+		require.NoError(t, err)
+
+		cfg.OrganizationSlug = "test-shorter-org-slug"
+		err = cfg.Save()
+
+		assert.NoError(t, err)
+		actual, err := os.ReadFile(filepath.Join(configBaseDir, "numerous", "config.toml"))
+		if assert.NoError(t, err) {
+			expected := "organization = \"test-shorter-org-slug\"\n"
 			assert.Equal(t, expected, string(actual))
 		}
 	})

--- a/internal/test/stdout.go
+++ b/internal/test/stdout.go
@@ -1,0 +1,39 @@
+package test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func PatchStdout(t *testing.T) (io.ReadCloser, io.WriteCloser) {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	realStdout := os.Stdout
+	t.Cleanup(func() {
+		os.Stdout = realStdout
+		w.Close()
+		r.Close()
+	})
+	os.Stdout = w
+
+	return r, w
+}
+
+// Patches Stdout, runs the function fn, and closes the stdout writer so that
+// the stdout reader can be read until the end.
+func RunWithPatchedStdout(t *testing.T, fn func() error) (io.Reader, error) {
+	t.Helper()
+
+	r, w := PatchStdout(t)
+	t.Cleanup(func() { r.Close() })
+	err := fn()
+	w.Close()
+
+	return r, err
+}

--- a/internal/test/stdout.go
+++ b/internal/test/stdout.go
@@ -8,7 +8,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func PatchStdout(t *testing.T) (io.ReadCloser, io.WriteCloser) {
+// Patches Stdout, runs the function fn, closes the stdout writer so that
+// the stdout reader can be read until the end, and returns a stdout reader and
+// any error returned by fn.
+func RunEWithPatchedStdout(t *testing.T, fn func() error) (io.Reader, error) {
+	t.Helper()
+
+	r, w := patchStdout(t)
+	err := fn()
+	w.Close()
+
+	return r, err
+}
+
+// Patches Stdout, runs the function fn, and closes the stdout writer so that
+// the stdout reader can be read until the end, and returns a stdout reader.
+func RunWithPatchedStdout(t *testing.T, fn func()) io.Reader {
+	t.Helper()
+
+	r, w := patchStdout(t)
+	fn()
+	w.Close()
+
+	return r
+}
+
+func patchStdout(t *testing.T) (io.ReadCloser, io.WriteCloser) {
 	t.Helper()
 
 	r, w, err := os.Pipe()
@@ -23,17 +48,4 @@ func PatchStdout(t *testing.T) (io.ReadCloser, io.WriteCloser) {
 	os.Stdout = w
 
 	return r, w
-}
-
-// Patches Stdout, runs the function fn, and closes the stdout writer so that
-// the stdout reader can be read until the end.
-func RunWithPatchedStdout(t *testing.T, fn func() error) (io.Reader, error) {
-	t.Helper()
-
-	r, w := PatchStdout(t)
-	t.Cleanup(func() { r.Close() })
-	err := fn()
-	w.Close()
-
-	return r, err
 }

--- a/internal/test/stdout_test.go
+++ b/internal/test/stdout_test.go
@@ -1,0 +1,52 @@
+package test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var errTest = errors.New("test error")
+
+func TestRunWithPatchedStdout(t *testing.T) {
+	t.Run("captures writes to stdout", func(t *testing.T) {
+		expected := "some printed text"
+
+		stdout := RunWithPatchedStdout(t, func() {
+			os.Stdout.WriteString(expected)
+		})
+
+		actual, err := io.ReadAll(stdout)
+
+		assert.NoError(t, err)
+		assert.Equal(t, expected, string(actual))
+	})
+}
+
+func TestRunEWithPatchedStdout(t *testing.T) {
+	t.Run("captures writes to stdout", func(t *testing.T) {
+		expected := "some printed text"
+
+		stdout, err := RunEWithPatchedStdout(t, func() error {
+			os.Stdout.WriteString(expected)
+			return nil
+		})
+
+		if assert.NoError(t, err) {
+			actual, err := io.ReadAll(stdout)
+			assert.NoError(t, err)
+			assert.Equal(t, expected, string(actual))
+		}
+	})
+
+	t.Run("returns expected error", func(t *testing.T) {
+		_, err := RunEWithPatchedStdout(t, func() error {
+			return errTest
+		})
+
+		assert.ErrorIs(t, err, errTest)
+	})
+}


### PR DESCRIPTION
* Adds `config` command which can be used to list or set configuration values
* Adds an `organization` config value that can be configured with an organization slug
* Uses the configured organization slug when getting app identifiers, as a fallback value if no organization slug is given in arguments or manifest deployment section