### PR TITLE
fix(python-sdk): loose dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         additional_dependencies:
           - "types-requests"
           - "pytest-asyncio"
-          - "pydantic<2.10.0"
+          - "pydantic>=2.9.0,<3.0.0"
           - "marimo==0.8.14"
   - repo: local
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "typing-extensions>=4.12.2",
     "requests>=2.32.3",
-    "httpx>=0.23,<0.28.0",
-    "pydantic>=2.9.0,<2.10.0",
+    "httpx>=0.23,<1.0",
+    "pydantic>=2.9.0,<3.0.0",
     "websockets>=0.11",
     "pathspec",
 ]

--- a/python/src/numerous/experimental/model.py
+++ b/python/src/numerous/experimental/model.py
@@ -203,7 +203,7 @@ class Field:
         A tuple containing the Pydantic Field object with the value and properties.
         """
         # Create a Pydantic Field object with the value and properties
-        self._field_info = PydanticField(self._default, **self._props)  # type: ignore[arg-type]
+        self._field_info = PydanticField(self._default, **self._props)  # type: ignore[arg-type,call-overload,unused-ignore]
         return self._field_info
 
     @property


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Loosens httpx and pydantic version ranges and updates pre-commit mypy deps; adds broader type-ignores in experimental model.
> 
> - **Dependencies**:
>   - Update `pyproject.toml` to relax version bounds:
>     - `httpx` from `<0.28.0` to `<1.0`.
>     - `pydantic` from `<2.10.0` to `<3.0.0`.
>   - Align `.pre-commit-config.yaml` mypy `additional_dependencies` to `pydantic>=2.9.0,<3.0.0`.
> - **Typing**:
>   - Broaden `# type: ignore` on `PydanticField(...)` in `python/src/numerous/experimental/model.py` to include `call-overload` and `unused-ignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43d1343ae3aca26697765c41fac86c075c74cfef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->