### PR TITLE
fix: static analysis alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,16 +8,14 @@ on:
     branches:
       - main
 
-permissions:
-  id-token: write
-  contents: write
-
 jobs:
   publish-sdk-coverage:
     name: Publish SDK test coverage
     timeout-minutes: 5
     runs-on: ubuntu-latest
     environment: main
+    permissions:
+      actions: read
     steps:
       - name: Download coverage percentage
         uses: dawidd6/action-download-artifact@v7
@@ -40,6 +38,8 @@ jobs:
     name: Publish CLI test coverage
     runs-on: ubuntu-latest
     environment: main
+    permissions:
+      actions: read
     steps:
       - name: Download coverage percentage
         uses: dawidd6/action-download-artifact@v7
@@ -64,6 +64,10 @@ jobs:
     environment: main
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,6 +8,8 @@ jobs:
     name: Lint python SDK
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -23,6 +25,9 @@ jobs:
     name: Unit test python SDK
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -41,6 +46,9 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     name: Build
+    permissions:
+      contents: read
+      actions: write
     strategy:
       matrix:
         platform: ["darwin_amd64", "darwin_arm64", "linux_amd64", "linux_arm64", "windows_amd64", "windows_arm64"]
@@ -68,6 +76,8 @@ jobs:
     name: Collect dists
     runs-on: ubuntu-latest
     needs: [build]
+    permissions:
+      actions: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -102,6 +112,9 @@ jobs:
     name: Test CLI on windows
     runs-on: windows-latest
     needs: [build]
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -121,6 +134,8 @@ jobs:
   lint-cli:
     name: Lint CLI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
@@ -155,6 +170,9 @@ jobs:
   test-cli:
     name: Unit test CLI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go

--- a/cmd/logs/logs_test.go
+++ b/cmd/logs/logs_test.go
@@ -93,6 +93,7 @@ func TestLogs(t *testing.T) {
 		apps.On("AppDeployLogs", ai, (*int)(nil), true).Return(ch, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		go func() {
 			time.Sleep(time.Millisecond * 10)
 			cancel()

--- a/cmd/task/instance/logs/logs_test.go
+++ b/cmd/task/instance/logs/logs_test.go
@@ -54,6 +54,7 @@ func TestTaskLogs(t *testing.T) {
 		service.On("TaskInstanceLogs", expectedInput).Return(ch, nil)
 
 		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		go func() {
 			time.Sleep(time.Millisecond * 10)
 			cancel()

--- a/internal/archive/tar.go
+++ b/internal/archive/tar.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"archive/tar"
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -88,7 +89,13 @@ func TarExtract(content io.Reader, dest string) error {
 			continue
 		}
 
-		target := filepath.Join(dest, header.Name)
+		// Sanitize the entry name before constructing the target path to prevent path traversal
+		entryName := filepath.Clean(filepath.FromSlash(header.Name))
+		if filepath.IsAbs(entryName) || entryName == ".." || strings.HasPrefix(entryName, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("illegal file path in archive: %s", header.Name)
+		}
+
+		target := filepath.Join(dest, entryName)
 
 		switch header.Typeflag {
 		case tar.TypeDir:

--- a/internal/manifest/manifest_v0.go
+++ b/internal/manifest/manifest_v0.go
@@ -20,7 +20,7 @@ type ManifestV0 struct {
 }
 
 func (d *ManifestV0) ToManifest() (*Manifest, error) {
-	port, err := strconv.ParseUint(d.Port, 10, 64)
+	port, err := strconv.ParseUint(d.Port, 10, strconv.IntSize)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
* Fix path traversal in tar extraction.
* Fix integer type conversion in manifest port parsing.
* Add explicit least-privilege permissions to validate and release workflows.